### PR TITLE
Add a manfiest for the Studienbuch that is not paged.

### DIFF
--- a/iiif/studienbuch_not_paged.json
+++ b/iiif/studienbuch_not_paged.json
@@ -1,0 +1,20475 @@
+{
+  "@context": [
+    "https://iiif.io/api/presentation/3/context.json"
+  ],
+  "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178",
+  "type": "Manifest",
+  "label": {
+    "en": [
+      "Studienbuch"
+    ]
+  },
+  "summary": {
+    "en": [
+      "Detailed commentary on the performance of selected piano works by Bach, Beethoven, Chopin, Liszt and Brahms. This copy includes handwritten notes charting out various concerts that Galston performed as part of his cycle of 40 historical recitals in Germany between 1919 and 1921."
+    ]
+  },
+  "metadata": [
+    {
+      "label": {
+        "en": [
+          "Table of Contents"
+        ]
+      },
+      "value": {
+        "en": [
+          "Vorwort -- Bach -- Beethoven -- Chopin -- Liszt -- Brahms -- Anhang -- Register"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Creators and Contributors"
+        ]
+      },
+      "value": {
+        "en": [
+          "Galston, Gottfried, 1879-1950",
+          "Ebert, K."
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Publisher"
+        ]
+      },
+      "value": {
+        "en": [
+          "Verlag Bruno Cassirer"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Publication Date"
+        ]
+      },
+      "value": {
+        "en": [
+          "1910",
+          "1910"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Form"
+        ]
+      },
+      "value": {
+        "en": [
+          "books"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Extent"
+        ]
+      },
+      "value": {
+        "en": [
+          "26 cm high",
+          "498 pages, spine of book"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Topic"
+        ]
+      },
+      "value": {
+        "en": [
+          "Music",
+          "Piano music"
+        ]
+      }
+    }
+  ],
+  "rights": "https://creativecommons.org/publicdomain/mark/1.0/",
+  "requiredStatement": {
+    "label": {
+      "en": [
+        "Attribution"
+      ]
+    },
+    "value": {
+      "en": [
+        "University of Tennessee, Knoxville. Libraries"
+      ]
+    }
+  },
+  "provider": [
+    {
+      "id": "https://www.lib.utk.edu/about/",
+      "type": "Agent",
+      "label": {
+        "en": [
+          "University of Tennessee, Knoxville. Libraries"
+        ]
+      },
+      "homepage": [
+        {
+          "id": "https://www.lib.utk.edu/",
+          "type": "Text",
+          "label": {
+            "en": [
+              "University of Tennessee Libraries Homepage"
+            ]
+          },
+          "format": "text/html"
+        }
+      ],
+      "logo": [
+        {
+          "id": "https://utkdigitalinitiatives.github.io/iiif-level-0/ut_libraries_centered/full/full/0/default.jpg",
+          "type": "Image",
+          "format": "image/jpeg",
+          "width": 200,
+          "height": 200
+        }
+      ]
+    }
+  ],
+  "thumbnail": [
+    {
+      "id": "https://digital.lib.utk.edu/collections/islandora/object/galston%3A178/datastream/JP2",
+      "type": "Image",
+      "format": "image/jpeg",
+      "width": 200,
+      "height": 200
+    }
+  ],
+  "items": [
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/0",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 1"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/0/page/galston:219",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/0/page/galston:219/610d90d86eabb",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:219~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:219~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/0"
+            }
+          ]
+        }
+      ],
+      "annotations": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/0/annotations",
+          "type": "AnnotationPage",
+          "label": "Studienbuch",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/0/annotations/1",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Front Cover"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/0#xywh=200,150,5150,8000"
+            },
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/0/annotations/2",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Front cover detail"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/0#xywh=2500,0,3000,2500"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/1",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 2"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/1/page/galston:181",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/1/page/galston:181/610d90d8cef9d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:181~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:181~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/1"
+            }
+          ]
+        }
+      ],
+      "annotations": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/1/annotations",
+          "type": "AnnotationPage",
+          "label": "Studienbuch",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/1/annotations/1",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Inside cover"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/1#xywh=4644,7616,1330,596"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/2",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 3"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/2/page/galston:448",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/2/page/galston:448/610d90d93b508",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:448~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:448~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/3",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 4"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/3/page/galston:190",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/3/page/galston:190/610d90d99bc69",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:190~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:190~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/4",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 5"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/4/page/galston:447",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/4/page/galston:447/610d90da0859c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:447~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:447~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/5",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 6"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/5/page/galston:227",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/5/page/galston:227/610d90da6909f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:227~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:227~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/5"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/6",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 7"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/6/page/galston:446",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/6/page/galston:446/610d90dac9afc",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:446~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:446~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/7",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 8"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/7/page/galston:189",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/7/page/galston:189/610d90db35c01",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:189~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:189~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/7"
+            }
+          ]
+        }
+      ],
+      "annotations": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/7/annotations",
+          "type": "AnnotationPage",
+          "label": "Studienbuch",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/7/annotations/1",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Printer's information"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/7#xywh=2968,5248,2392,1536"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/8",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 9"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/8/page/galston:445",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/8/page/galston:445/610d90db96699",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:445~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:445~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/8"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/9",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 10"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/9/page/galston:226",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/9/page/galston:226/610d90dc02eb3",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:226~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:226~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/10",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 11"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/10/page/galston:444",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/10/page/galston:444/610d90dc635c7",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:444~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:444~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/10"
+            }
+          ]
+        }
+      ],
+      "annotations": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/10/annotations",
+          "type": "AnnotationPage",
+          "label": "Studienbuch",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/10/annotations/1",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - First Edition"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/10#xywh=472,1448,3304,2240"
+            },
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/10/annotations/2",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Publisher's Mark"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/10#xywh=1032,4264,2168,1968"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/11",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 12"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/11/page/galston:188",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/11/page/galston:188/610d90dcc40cb",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:188~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:188~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/11"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/12",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 13"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/12/page/galston:443",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/12/page/galston:443/610d90dd30579",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:443~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:443~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/12"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/13",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 14"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/13/page/galston:225",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/13/page/galston:225/610d90dd91060",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:225~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:225~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/13"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/14",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 15"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/14/page/galston:442",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/14/page/galston:442/610d90ddf1b70",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:442~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:442~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/14"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/15",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 16"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/15/page/galston:187",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/15/page/galston:187/610d90de5e43b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:187~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:187~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/15"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/16",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 17"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/16/page/galston:441",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/16/page/galston:441/610d90debebe0",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:441~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:441~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/16"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/17",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 18"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/17/page/galston:224",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/17/page/galston:224/610d90df2b421",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:224~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:224~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/17"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/18",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 19"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/18/page/galston:440",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/18/page/galston:440/610d90df8bb27",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:440~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:440~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/18"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/19",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 20"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/19/page/galston:186",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/19/page/galston:186/610d90dfec545",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:186~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:186~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/19"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/20",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 21"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/20/page/galston:439",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/20/page/galston:439/610d90e0591cc",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:439~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:439~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/20"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/21",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 22"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/21/page/galston:223",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/21/page/galston:223/610d90e0ba228",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:223~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:223~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/21"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/22",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 23"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/22/page/galston:438",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/22/page/galston:438/610d90e126625",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:438~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:438~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/22"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/23",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 24"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/23/page/galston:185",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/23/page/galston:185/610d90e18708e",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:185~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:185~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/23"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/24",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 25"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/24/page/galston:437",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/24/page/galston:437/610d90e1e7be2",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:437~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:437~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/24"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/25",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 26"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/25/page/galston:222",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/25/page/galston:222/610d90e254356",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:222~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:222~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/25"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/26",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 27"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/26/page/galston:436",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/26/page/galston:436/610d90e2b4645",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:436~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:436~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/26"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/27",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 28"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/27/page/galston:184",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/27/page/galston:184/610d90e320ffb",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:184~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:184~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/27"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/28",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 29"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/28/page/galston:435",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/28/page/galston:435/610d90e381b15",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:435~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:435~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/28"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/29",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 30"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/29/page/galston:221",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/29/page/galston:221/610d90e3e25ec",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:221~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:221~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/29"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/30",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 31"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/30/page/galston:179",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/30/page/galston:179/610d90e44ee7b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:179~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:179~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/30"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/31",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 32"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/31/page/galston:183",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/31/page/galston:183/610d90e4afe58",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:183~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:183~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/31"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/32",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 33"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/32/page/galston:676",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/32/page/galston:676/610d90e51ccbe",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:676~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:676~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/32"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/33",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 34"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/33/page/galston:434",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/33/page/galston:434/610d90e57e46c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:434~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:434~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/33"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/34",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 35"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/34/page/galston:675",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/34/page/galston:675/610d90e5df464",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:675~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:675~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/34"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/35",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 36"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/35/page/galston:433",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/35/page/galston:433/610d90e64c06f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:433~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:433~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/35"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/36",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 37"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/36/page/galston:674",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/36/page/galston:674/610d90e6ac9ba",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:674~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:674~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/36"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/37",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 38"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/37/page/galston:432",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/37/page/galston:432/610d90e71927c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:432~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:432~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/37"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/38",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 39"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/38/page/galston:673",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/38/page/galston:673/610d90e779d7f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:673~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:673~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/38"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/39",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 40"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/39/page/galston:431",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/39/page/galston:431/610d90e7da107",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:431~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:431~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/39"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/40",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 41"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/40/page/galston:672",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/40/page/galston:672/610d90e8469b8",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:672~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:672~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/40"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/41",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 42"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/41/page/galston:430",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/41/page/galston:430/610d90e8a74c3",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:430~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:430~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/41"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/42",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 43"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/42/page/galston:671",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/42/page/galston:671/610d90e913db3",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:671~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:671~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/42"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/43",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 44"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/43/page/galston:429",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/43/page/galston:429/610d90e9747f1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:429~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:429~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/43"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/44",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 45"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/44/page/galston:670",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/44/page/galston:670/610d90e9d52c9",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:670~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:670~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/44"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/45",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 46"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/45/page/galston:428",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/45/page/galston:428/610d90ea41a5a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:428~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:428~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/45"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/46",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 47"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/46/page/galston:669",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/46/page/galston:669/610d90eaa298d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:669~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:669~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/46"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/47",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 48"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/47/page/galston:427",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/47/page/galston:427/610d90eb0ee40",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:427~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:427~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/47"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/48",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 49"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/48/page/galston:668",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/48/page/galston:668/610d90eb6fa51",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:668~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:668~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/48"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/49",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 50"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/49/page/galston:426",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/49/page/galston:426/610d90ebd04f0",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:426~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:426~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/49"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/50",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 51"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/50/page/galston:667",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/50/page/galston:667/610d90ec3ccc4",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:667~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:667~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/50"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/51",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 52"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/51/page/galston:425",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/51/page/galston:425/610d90ec9db6d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:425~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:425~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/51"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/52",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 53"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/52/page/galston:666",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/52/page/galston:666/610d90ed0a8aa",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:666~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:666~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/52"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/53",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 54"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/53/page/galston:424",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/53/page/galston:424/610d90ed6b4ad",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:424~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:424~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/53"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/54",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 55"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/54/page/galston:665",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/54/page/galston:665/610d90edcc158",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:665~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:665~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/54"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/55",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 56"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/55/page/galston:423",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/55/page/galston:423/610d90ee38ae3",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:423~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:423~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/55"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/56",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 57"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/56/page/galston:664",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/56/page/galston:664/610d90ee994ea",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:664~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:664~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/56"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/57",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 58"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/57/page/galston:422",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/57/page/galston:422/610d90ef084d5",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:422~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:422~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/57"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/58",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 59"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/58/page/galston:663",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/58/page/galston:663/610d90ef68b34",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:663~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:663~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/58"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/59",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 60"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/59/page/galston:218",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/59/page/galston:218/610d90efc936e",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:218~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:218~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/59"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/60",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 61"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/60/page/galston:662",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/60/page/galston:662/610d90f035abb",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:662~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:662~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/60"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/61",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 62"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/61/page/galston:421",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/61/page/galston:421/610d90f095e04",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:421~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:421~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/61"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/62",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 63"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/62/page/galston:661",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/62/page/galston:661/610d90f10274f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:661~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:661~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/62"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/63",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 64"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/63/page/galston:420",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/63/page/galston:420/610d90f162e16",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:420~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:420~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/63"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/64",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 65"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/64/page/galston:660",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/64/page/galston:660/610d90f1c39a1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:660~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:660~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/64"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/65",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 66"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/65/page/galston:419",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/65/page/galston:419/610d90f22fac1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:419~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:419~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/65"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/66",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 67"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/66/page/galston:659",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/66/page/galston:659/610d90f290987",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:659~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:659~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/66"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/67",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 68"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/67/page/galston:418",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/67/page/galston:418/610d90f2f1853",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:418~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:418~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/67"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/68",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 69"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/68/page/galston:658",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/68/page/galston:658/610d90f35e068",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:658~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:658~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/68"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/69",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 70"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/69/page/galston:417",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/69/page/galston:417/610d90f3beb30",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:417~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:417~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/69"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/70",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 71"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/70/page/galston:657",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/70/page/galston:657/610d90f42b796",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:657~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:657~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/70"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/71",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 72"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/71/page/galston:416",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/71/page/galston:416/610d90f48be5e",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:416~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:416~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/71"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/72",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 73"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/72/page/galston:656",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/72/page/galston:656/610d90f4ec952",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:656~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:656~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/72"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/73",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 74"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/73/page/galston:415",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/73/page/galston:415/610d90f5592dc",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:415~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:415~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/73"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/74",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 75"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/74/page/galston:655",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/74/page/galston:655/610d90f5b9967",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:655~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:655~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/74"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/75",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 76"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/75/page/galston:414",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/75/page/galston:414/610d90f626294",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:414~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:414~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/75"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/76",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 77"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/76/page/galston:654",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/76/page/galston:654/610d90f686db5",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:654~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:654~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/76"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/77",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 78"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/77/page/galston:413",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/77/page/galston:413/610d90f6e801b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:413~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:413~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/77"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/78",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 79"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/78/page/galston:653",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/78/page/galston:653/610d90f754c3c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:653~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:653~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/78"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/79",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 80"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/79/page/galston:412",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/79/page/galston:412/610d90f7b5a68",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:412~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:412~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/79"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/80",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 81"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/80/page/galston:652",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/80/page/galston:652/610d90f82273b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:652~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:652~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/80"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/81",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 82"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/81/page/galston:411",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/81/page/galston:411/610d90f8836ac",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:411~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:411~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/81"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/82",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 83"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/82/page/galston:651",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/82/page/galston:651/610d90f8e4a2a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:651~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:651~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/82"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/83",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 84"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/83/page/galston:410",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/83/page/galston:410/610d90f951959",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:410~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:410~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/83"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/84",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 85"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/84/page/galston:650",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/84/page/galston:650/610d90f9b25ab",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:650~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:650~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/84"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/85",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 86"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/85/page/galston:409",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/85/page/galston:409/610d90fa1f43f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:409~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:409~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/85"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/86",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 87"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/86/page/galston:649",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/86/page/galston:649/610d90fa7ff9a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:649~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:649~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/86"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/87",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 88"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/87/page/galston:408",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/87/page/galston:408/610d90fae0971",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:408~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:408~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/87"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/88",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 89"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/88/page/galston:648",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/88/page/galston:648/610d90fb4d394",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:648~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:648~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/88"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/89",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 90"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/89/page/galston:407",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/89/page/galston:407/610d90fbae1c9",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:407~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:407~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/89"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/90",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 91"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/90/page/galston:647",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/90/page/galston:647/610d90fc1aaa5",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:647~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:647~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/90"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/91",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 92"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/91/page/galston:406",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/91/page/galston:406/610d90fc7b142",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:406~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:406~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/91"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/92",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 93"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/92/page/galston:646",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/92/page/galston:646/610d90fcdbff2",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:646~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:646~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/92"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/93",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 94"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/93/page/galston:405",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/93/page/galston:405/610d90fd4a9bf",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:405~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:405~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/93"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/94",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 95"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/94/page/galston:645",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/94/page/galston:645/610d90fdab33b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:645~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:645~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/94"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/95",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 96"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/95/page/galston:404",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/95/page/galston:404/610d90fe17b6d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:404~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:404~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/95"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/96",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 97"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/96/page/galston:644",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/96/page/galston:644/610d90fe7868b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:644~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:644~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/96"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/97",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 98"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/97/page/galston:403",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/97/page/galston:403/610d90fed93e0",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:403~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:403~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/97"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/98",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 99"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/98/page/galston:643",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/98/page/galston:643/610d90ff45660",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:643~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:643~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/98"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/99",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 100"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/99/page/galston:402",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/99/page/galston:402/610d90ffa6846",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:402~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:402~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/99"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/100",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 101"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/100/page/galston:642",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/100/page/galston:642/610d910013591",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:642~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:642~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/100"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/101",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 102"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/101/page/galston:401",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/101/page/galston:401/610d9100743ff",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:401~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:401~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/101"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/102",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 103"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/102/page/galston:641",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/102/page/galston:641/610d9100d572f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:641~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:641~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/102"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/103",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 104"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/103/page/galston:400",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/103/page/galston:400/610d910142089",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:400~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:400~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/103"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/104",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 105"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/104/page/galston:640",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/104/page/galston:640/610d9101a32c9",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:640~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:640~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/104"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/105",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 106"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/105/page/galston:399",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/105/page/galston:399/610d910210381",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:399~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:399~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/105"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/106",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 107"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/106/page/galston:639",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/106/page/galston:639/610d9102722a7",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:639~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:639~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/106"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/107",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 108"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/107/page/galston:398",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/107/page/galston:398/610d9102d2b71",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:398~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:398~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/107"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/108",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 109"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/108/page/galston:638",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/108/page/galston:638/610d91033fc69",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:638~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:638~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/108"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/109",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 110"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/109/page/galston:397",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/109/page/galston:397/610d9103a066b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:397~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:397~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/109"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/110",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 111"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/110/page/galston:637",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/110/page/galston:637/610d91040d438",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:637~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:637~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/110"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/111",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 112"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/111/page/galston:396",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/111/page/galston:396/610d91046de35",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:396~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:396~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/111"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/112",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 113"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/112/page/galston:636",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/112/page/galston:636/610d9104ce9a8",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:636~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:636~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/112"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/113",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 114"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/113/page/galston:395",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/113/page/galston:395/610d91053b252",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:395~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:395~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/113"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/114",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 115"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/114/page/galston:635",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/114/page/galston:635/610d91059c4de",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:635~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:635~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/114"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/115",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 116"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/115/page/galston:394",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/115/page/galston:394/610d910608d53",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:394~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:394~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/115"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/116",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 117"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/116/page/galston:634",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/116/page/galston:634/610d910669b86",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:634~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:634~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/116"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/117",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 118"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/117/page/galston:393",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/117/page/galston:393/610d9106ca661",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:393~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:393~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/117"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/118",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 119"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/118/page/galston:633",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/118/page/galston:633/610d910737359",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:633~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:633~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/118"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/119",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 120"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/119/page/galston:392",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/119/page/galston:392/610d91079816c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:392~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:392~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/119"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/120",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 121"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/120/page/galston:632",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/120/page/galston:632/610d910804f17",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:632~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:632~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/120"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/121",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 122"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/121/page/galston:391",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/121/page/galston:391/610d910866307",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:391~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:391~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/121"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/122",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 123"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/122/page/galston:631",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/122/page/galston:631/610d9108c709e",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:631~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:631~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/122"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/123",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 124"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/123/page/galston:390",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/123/page/galston:390/610d9109338df",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:390~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:390~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/123"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/124",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 125"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/124/page/galston:630",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/124/page/galston:630/610d9109942d7",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:630~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:630~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/124"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/125",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 126"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/125/page/galston:389",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/125/page/galston:389/610d910a00db6",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:389~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:389~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/125"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/126",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 127"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/126/page/galston:629",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/126/page/galston:629/610d910a61bad",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:629~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:629~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/126"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/127",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 128"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/127/page/galston:388",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/127/page/galston:388/610d910ac2f1b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:388~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:388~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/127"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/128",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 129"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/128/page/galston:628",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/128/page/galston:628/610d910b2f81d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:628~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:628~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/128"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/129",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 130"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/129/page/galston:387",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/129/page/galston:387/610d910b90310",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:387~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:387~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/129"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/130",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 131"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/130/page/galston:627",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/130/page/galston:627/610d910bf1361",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:627~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:627~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/130"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/131",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 132"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/131/page/galston:386",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/131/page/galston:386/610d910c5dd25",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:386~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:386~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/131"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/132",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 133"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/132/page/galston:626",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/132/page/galston:626/610d910cbeb76",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:626~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:626~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/132"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/133",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 134"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/133/page/galston:385",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/133/page/galston:385/610d910d2b74c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:385~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:385~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/133"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/134",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 135"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/134/page/galston:625",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/134/page/galston:625/610d910d8c2da",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:625~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:625~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/134"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/135",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 136"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/135/page/galston:384",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/135/page/galston:384/610d910ded550",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:384~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:384~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/135"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/136",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 137"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/136/page/galston:624",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/136/page/galston:624/610d910e59dfa",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:624~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:624~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/136"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/137",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 138"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/137/page/galston:383",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/137/page/galston:383/610d910ebc813",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:383~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:383~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/137"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/138",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 139"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/138/page/galston:623",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/138/page/galston:623/610d910f294d5",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:623~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:623~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/138"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/139",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 140"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/139/page/galston:382",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/139/page/galston:382/610d910f8a097",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:382~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:382~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/139"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/140",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 141"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/140/page/galston:622",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/140/page/galston:622/610d910feae31",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:622~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:622~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/140"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/141",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 142"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/141/page/galston:381",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/141/page/galston:381/610d911057549",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:381~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:381~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/141"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/142",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 143"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/142/page/galston:621",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/142/page/galston:621/610d9110b8506",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:621~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:621~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/142"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/143",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 144"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/143/page/galston:380",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/143/page/galston:380/610d91112524d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:380~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:380~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/143"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/144",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 145"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/144/page/galston:620",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/144/page/galston:620/610d911186490",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:620~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:620~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/144"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/145",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 146"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/145/page/galston:379",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/145/page/galston:379/610d9111e703c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:379~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:379~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/145"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/146",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 147"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/146/page/galston:619",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/146/page/galston:619/610d9112538bd",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:619~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:619~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/146"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/147",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 148"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/147/page/galston:378",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/147/page/galston:378/610d9112b436e",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:378~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:378~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/147"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/148",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 149"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/148/page/galston:618",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/148/page/galston:618/610d911320f45",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:618~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:618~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/148"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/149",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 150"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/149/page/galston:377",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/149/page/galston:377/610d9113819dd",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:377~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:377~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/149"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/150",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 151"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/150/page/galston:617",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/150/page/galston:617/610d9113e2981",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:617~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:617~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/150"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/151",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 152"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/151/page/galston:376",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/151/page/galston:376/610d91144f239",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:376~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:376~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/151"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/152",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 153"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/152/page/galston:616",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/152/page/galston:616/610d9114afccc",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:616~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:616~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/152"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/153",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 154"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/153/page/galston:375",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/153/page/galston:375/610d91151ca6d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:375~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:375~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/153"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/154",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 155"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/154/page/galston:615",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/154/page/galston:615/610d91157d3d7",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:615~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:615~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/154"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/155",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 156"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/155/page/galston:374",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/155/page/galston:374/610d9115ddf1c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:374~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:374~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/155"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/156",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 157"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/156/page/galston:614",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/156/page/galston:614/610d91164a913",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:614~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:614~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/156"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/157",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 158"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/157/page/galston:373",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/157/page/galston:373/610d9116ab6d7",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:373~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:373~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/157"
+            }
+          ]
+        }
+      ],
+      "annotations": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/157/annotations",
+          "type": "AnnotationPage",
+          "label": "Studienbuch: page 158",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/157/annotations/1",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Galston makes four editorial changes in the Chopin section."
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/157#xywh=1312,288,4640,7712"
+            },
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/157/annotations/2",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Handwritten note in Chopin section"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/157#xywh=1544,5816,4464,624"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/158",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 159"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/158/page/galston:613",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/158/page/galston:613/610d911717e93",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:613~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:613~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/158"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/159",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 160"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/159/page/galston:372",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/159/page/galston:372/610d911778ad3",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:372~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:372~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/159"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/160",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 161"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/160/page/galston:612",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/160/page/galston:612/610d9117d9dcc",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:612~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:612~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/160"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/161",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 162"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/161/page/galston:371",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/161/page/galston:371/610d911846bb0",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:371~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:371~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/161"
+            }
+          ]
+        }
+      ],
+      "annotations": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/161/annotations",
+          "type": "AnnotationPage",
+          "label": "Studienbuch: page 162",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/161/annotations/1",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "x Vor-Parallestudium (Transponieren durch mehrere Tonarten) zum Finale des hmoll Sonate!\n=======\nx Pre-parallel study (transposition through several keys) to the final of the b-minor sonata!"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/161#xywh=1632,2288,4160,1424"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/162",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 163"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/162/page/galston:611",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/162/page/galston:611/610d9118a7c78",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:611~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:611~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/162"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/163",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 164"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/163/page/galston:370",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/163/page/galston:370/610d911914e61",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:370~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:370~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/163"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/164",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 165"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/164/page/galston:610",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/164/page/galston:610/610d911976072",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:610~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:610~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/164"
+            }
+          ]
+        }
+      ],
+      "annotations": [
+        [
+          {
+            "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/164/annotations",
+            "type": "AnnotationPage",
+            "label": "Studienbuch: page 165",
+            "items": [
+              {
+                "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/164/annotations/1",
+                "type": "Annotation",
+                "motivation": "commenting",
+                "body": {
+                  "type": "FragmentSelector",
+                  "language": "en",
+                  "value": "Dieses Studienmaterial mit den Komplexen der Etüde Op 10 No 2 amoll kombinieren. Technische Verwandtschaft\nx x x\n============\nCombine this study material with the issues related to the étude Op 10 No 2 in a-minor. Technical relationship.\nx x x"
+                },
+                "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/164#xywh=320,3488,4256,1248"
+              }
+            ]
+          }
+        ]
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/165",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 166"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/165/page/galston:369",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/165/page/galston:369/610d9119d7642",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:369~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:369~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/165"
+            }
+          ]
+        }
+      ],
+      "annotations": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/165/annotations",
+          "type": "AnnotationPage",
+          "label": "Studienbuch: page 166",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/165/annotations/1",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Die charakteristischen technischen Laufgruppen (z.B. Takte 1-2, 29-32 u.s.w.) zu fortlaufenden Fingerüberungen durch alle 12 Tonarten benützen: Zur Befestigung und Ausbildung des 6 Pianistensinns des Distanzgefühls (in Spannung und Sprung) . \nx x x\n=======\nUse the characteristic technical runs (e.g. measures 1-2, 29-32 etc.) for extended fingering practice through all 12 keys: For the development and establishment of the 6th pianistic sense of distance (in tension and leap).\nx x x"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/165#xywh=1712,4864,4160,1440"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/166",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 167"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/166/page/galston:609",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/166/page/galston:609/610d911a44050",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:609~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:609~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/166"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/167",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 168"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/167/page/galston:368",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/167/page/galston:368/610d911aa4d6d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:368~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:368~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/167"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/168",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 169"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/168/page/galston:608",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/168/page/galston:608/610d911b11ab0",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:608~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:608~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/168"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/169",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 170"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/169/page/galston:367",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/169/page/galston:367/610d911b7257a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:367~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:367~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/169"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/170",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 171"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/170/page/galston:607",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/170/page/galston:607/610d911bd2f11",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:607~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:607~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/170"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/171",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 172"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/171/page/galston:366",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/171/page/galston:366/610d911c3f914",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:366~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:366~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/171"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/172",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 173"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/172/page/galston:606",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/172/page/galston:606/610d911ca067a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:606~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:606~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/172"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/173",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 174"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/173/page/galston:365",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/173/page/galston:365/610d911d0d3d7",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:365~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:365~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/173"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/174",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 175"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/174/page/galston:605",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/174/page/galston:605/610d911d6e37e",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:605~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:605~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/174"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/175",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 176"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/175/page/galston:364",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/175/page/galston:364/610d911dcef58",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:364~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:364~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/175"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/176",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 177"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/176/page/galston:604",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/176/page/galston:604/610d911e3b578",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:604~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:604~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/176"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/177",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 178"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/177/page/galston:363",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/177/page/galston:363/610d911e9c914",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:363~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:363~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/177"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/178",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 179"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/178/page/galston:603",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/178/page/galston:603/610d911f0914c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:603~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:603~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/178"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/179",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 180"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/179/page/galston:362",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/179/page/galston:362/610d911f69792",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:362~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:362~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/179"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/180",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 181"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/180/page/galston:602",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/180/page/galston:602/610d911fca3af",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:602~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:602~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/180"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/181",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 182"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/181/page/galston:361",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/181/page/galston:361/610d912036f2a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:361~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:361~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/181"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/182",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 183"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/182/page/galston:601",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/182/page/galston:601/610d9120979d8",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:601~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:601~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/182"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/183",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 184"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/183/page/galston:360",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/183/page/galston:360/610d912150652",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:360~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:360~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/183"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/184",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 185"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/184/page/galston:600",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/184/page/galston:600/610d912254894",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:600~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:600~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/184"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/185",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 186"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/185/page/galston:359",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/185/page/galston:359/610d91238eb69",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:359~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:359~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/185"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/186",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 187"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/186/page/galston:599",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/186/page/galston:599/610d9124c9bc7",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:599~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:599~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/186"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/187",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 188"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/187/page/galston:358",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/187/page/galston:358/610d91260e10f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:358~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:358~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/187"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/188",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 189"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/188/page/galston:598",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/188/page/galston:598/610d9127374cf",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:598~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:598~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/188"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/189",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 190"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/189/page/galston:357",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/189/page/galston:357/610d912798549",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:357~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:357~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/189"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/190",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 191"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/190/page/galston:597",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/190/page/galston:597/610d9128052de",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:597~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:597~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/190"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/191",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 192"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/191/page/galston:356",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/191/page/galston:356/610d912866235",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:356~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:356~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/191"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/192",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 193"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/192/page/galston:596",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/192/page/galston:596/610d9128c708a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:596~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:596~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/192"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/193",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 194"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/193/page/galston:355",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/193/page/galston:355/610d912933d50",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:355~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:355~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/193"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/194",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 195"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/194/page/galston:595",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/194/page/galston:595/610d9129974ee",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:595~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:595~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/194"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/195",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 196"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/195/page/galston:354",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/195/page/galston:354/610d912a04b81",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:354~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:354~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/195"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/196",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 197"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/196/page/galston:594",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/196/page/galston:594/610d912a65569",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:594~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:594~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/196"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/197",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 198"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/197/page/galston:353",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/197/page/galston:353/610d912ac6406",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:353~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:353~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/197"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/198",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 199"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/198/page/galston:593",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/198/page/galston:593/610d912b32cc4",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:593~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:593~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/198"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/199",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 200"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/199/page/galston:352",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/199/page/galston:352/610d912b93b98",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:352~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:352~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/199"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/200",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 201"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/200/page/galston:592",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/200/page/galston:592/610d912c02e40",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:592~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:592~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/200"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/201",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 202"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/201/page/galston:351",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/201/page/galston:351/610d912c63b47",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:351~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:351~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/201"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/202",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 203"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/202/page/galston:591",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/202/page/galston:591/610d912cc460a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:591~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:591~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/202"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/203",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 204"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/203/page/galston:350",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/203/page/galston:350/610d912dea2ef",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:350~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:350~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/203"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/204",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 205"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/204/page/galston:590",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/204/page/galston:590/610d912f2e79b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:590~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:590~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/204"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/205",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 206"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/205/page/galston:349",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/205/page/galston:349/610d91306429c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:349~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:349~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/205"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/206",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 207"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/206/page/galston:589",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/206/page/galston:589/610d913192c5a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:589~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:589~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/206"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/207",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 208"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/207/page/galston:348",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/207/page/galston:348/610d9132bcdbd",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:348~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:348~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/207"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/208",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 209"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/208/page/galston:588",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/208/page/galston:588/610d9133eee1e",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:588~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:588~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/208"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/209",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 210"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/209/page/galston:347",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/209/page/galston:347/610d913529bdf",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:347~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:347~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/209"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/210",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 211"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/210/page/galston:587",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/210/page/galston:587/610d913650765",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:587~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:587~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/210"
+            }
+          ]
+        }
+      ],
+      "annotations": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/210/annotations",
+          "type": "AnnotationPage",
+          "label": "Studienbuch: page 211",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/210/annotations/1",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "The piece appears on page 210 in the Studienbuch's Appendices (Anhang). It was also published in Ferruccio Busoni's 1922 book, Von der Einheit der Musik (Of the Unity of Music). and was reportedly included in Busoni's Zurich program of April 1916."
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/210#xywh=272,1328,3712,5440"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/211",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 212"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/211/page/galston:346",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/211/page/galston:346/610d913781ad7",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:346~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:346~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/211"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/212",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 213"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/212/page/galston:586",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/212/page/galston:586/610d9138ada33",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:586~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:586~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/212"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/213",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 214"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/213/page/galston:345",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/213/page/galston:345/610d9139daea9",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:345~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:345~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/213"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/214",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 215"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/214/page/galston:585",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/214/page/galston:585/610d913b14144",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:585~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:585~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/214"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/215",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 216"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/215/page/galston:344",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/215/page/galston:344/610d913c4822e",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:344~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:344~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/215"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/216",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 217"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/216/page/galston:584",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/216/page/galston:584/610d913d7df4e",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:584~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:584~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/216"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/217",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 218"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/217/page/galston:343",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/217/page/galston:343/610d913eb1d0f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:343~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:343~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/217"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/218",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 219"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/218/page/galston:583",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/218/page/galston:583/610d913fe2396",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:583~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:583~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/218"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/219",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 220"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/219/page/galston:342",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/219/page/galston:342/610d914111b32",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:342~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:342~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/219"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/220",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 221"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/220/page/galston:582",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/220/page/galston:582/610d91423d1a5",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:582~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:582~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/220"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/221",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 222"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/221/page/galston:341",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/221/page/galston:341/610d914373134",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:341~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:341~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/221"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/222",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 223"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/222/page/galston:581",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/222/page/galston:581/610d9144a884b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:581~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:581~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/222"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/223",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 224"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/223/page/galston:340",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/223/page/galston:340/610d9145d8e19",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:340~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:340~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/223"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/224",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 225"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/224/page/galston:580",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/224/page/galston:580/610d914718775",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:580~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:580~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/224"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/225",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 226"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/225/page/galston:339",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/225/page/galston:339/610d914840951",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:339~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:339~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/225"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/226",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 227"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/226/page/galston:579",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/226/page/galston:579/610d91497345a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:579~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:579~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/226"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/227",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 228"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/227/page/galston:338",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/227/page/galston:338/610d914aa61e0",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:338~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:338~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/227"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/228",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 229"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/228/page/galston:578",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/228/page/galston:578/610d914bce25f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:578~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:578~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/228"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/229",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 230"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/229/page/galston:337",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/229/page/galston:337/610d914d0f6c2",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:337~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:337~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/229"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/230",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 231"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/230/page/galston:577",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/230/page/galston:577/610d914e4072a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:577~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:577~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/230"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/231",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 232"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/231/page/galston:336",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/231/page/galston:336/610d914f710ee",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:336~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:336~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/231"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/232",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 233"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/232/page/galston:576",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/232/page/galston:576/610d9150ab2b7",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:576~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:576~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/232"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/233",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 234"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/233/page/galston:335",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/233/page/galston:335/610d91521c372",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:335~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:335~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/233"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/234",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 235"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/234/page/galston:575",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/234/page/galston:575/610d91534fa54",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:575~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:575~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/234"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/235",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 236"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/235/page/galston:334",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/235/page/galston:334/610d915486944",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:334~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:334~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/235"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/236",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 237"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/236/page/galston:574",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/236/page/galston:574/610d9155c1566",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:574~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:574~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/236"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/237",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 238"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/237/page/galston:333",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/237/page/galston:333/610d91570a1a2",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:333~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:333~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/237"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/238",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 239"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/238/page/galston:573",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/238/page/galston:573/610d91583f207",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:573~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:573~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/238"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/239",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 240"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/239/page/galston:332",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/239/page/galston:332/610d915980f23",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:332~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:332~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/239"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/240",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 241"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/240/page/galston:572",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/240/page/galston:572/610d915ab769c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:572~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:572~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/240"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/241",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 242"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/241/page/galston:331",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/241/page/galston:331/610d915bd96e7",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:331~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:331~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/241"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/242",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 243"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/242/page/galston:571",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/242/page/galston:571/610d915d187ad",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:571~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:571~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/242"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/243",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 244"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/243/page/galston:330",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/243/page/galston:330/610d915e47a1e",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:330~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:330~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/243"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/244",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 245"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/244/page/galston:570",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/244/page/galston:570/610d915f88501",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:570~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:570~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/244"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/245",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 246"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/245/page/galston:329",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/245/page/galston:329/610d9160cdf4b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:329~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:329~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/245"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/246",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 247"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/246/page/galston:569",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/246/page/galston:569/610d91620c0fa",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:569~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:569~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/246"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/247",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 248"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/247/page/galston:328",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/247/page/galston:328/610d916331ef1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:328~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:328~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/247"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/248",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 249"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/248/page/galston:568",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/248/page/galston:568/610d916457c8e",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:568~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:568~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/248"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/249",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 250"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/249/page/galston:327",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/249/page/galston:327/610d91659423e",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:327~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:327~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/249"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/250",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 251"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/250/page/galston:567",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/250/page/galston:567/610d9166d10b6",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:567~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:567~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/250"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/251",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 252"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/251/page/galston:326",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/251/page/galston:326/610d91681e119",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:326~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:326~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/251"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/252",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 253"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/252/page/galston:566",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/252/page/galston:566/610d91695b654",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:566~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:566~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/252"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/253",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 254"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/253/page/galston:325",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/253/page/galston:325/610d916a7e098",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:325~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:325~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/253"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/254",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 255"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/254/page/galston:565",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/254/page/galston:565/610d916baef31",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:565~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:565~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/254"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/255",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 256"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/255/page/galston:324",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/255/page/galston:324/610d916ce9757",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:324~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:324~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/255"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/256",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 257"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/256/page/galston:564",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/256/page/galston:564/610d916e2390a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:564~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:564~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/256"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/257",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 258"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/257/page/galston:323",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/257/page/galston:323/610d916f4c744",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:323~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:323~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/257"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/258",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 259"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/258/page/galston:563",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/258/page/galston:563/610d917075cdb",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:563~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:563~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/258"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/259",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 260"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/259/page/galston:322",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/259/page/galston:322/610d9170d6bd8",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:322~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:322~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/259"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/260",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 261"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/260/page/galston:562",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/260/page/galston:562/610d917143339",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:562~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:562~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/260"
+            }
+          ]
+        }
+      ],
+      "annotations": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/260/annotations",
+          "type": "AnnotationPage",
+          "label": "Studienbuch",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/260/annotations/1",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Godowsky postcard"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/260#xywh=656,48,3952,3840"
+            },
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/260/annotations/2",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Godowsky postcard detail"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/260#xywh=1512,360,2120,1696"
+            },
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/260/annotations/3",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Godowsky postcard additional detail"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/260#xywh=1744,2024,1672,1008"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/261",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 262"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/261/page/galston:321",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/261/page/galston:321/610d9172786f1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:321~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:321~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/261"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/262",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 263"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/262/page/galston:561",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/262/page/galston:561/610d9173a9c9b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:561~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:561~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/262"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/263",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 264"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/263/page/galston:320",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/263/page/galston:320/610d9174dbc48",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:320~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:320~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/263"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/264",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 265"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/264/page/galston:560",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/264/page/galston:560/610d91761331b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:560~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:560~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/264"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/265",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 266"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/265/page/galston:319",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/265/page/galston:319/610d91773a0bf",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:319~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:319~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/265"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/266",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 267"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/266/page/galston:559",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/266/page/galston:559/610d91788956c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:559~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:559~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/266"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/267",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 268"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/267/page/galston:318",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/267/page/galston:318/610d9179bb662",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:318~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:318~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/267"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/268",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 269"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/268/page/galston:558",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/268/page/galston:558/610d917aeed58",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:558~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:558~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/268"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/269",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 270"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/269/page/galston:317",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/269/page/galston:317/610d917c1c9d1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:317~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:317~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/269"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/270",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 271"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/270/page/galston:557",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/270/page/galston:557/610d917d41b42",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:557~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:557~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/270"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/271",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 272"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/271/page/galston:316",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/271/page/galston:316/610d917e652cb",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:316~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:316~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/271"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/272",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 273"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/272/page/galston:556",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/272/page/galston:556/610d917f89727",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:556~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:556~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/272"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/273",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 274"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/273/page/galston:315",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/273/page/galston:315/610d9180b1189",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:315~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:315~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/273"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/274",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 275"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/274/page/galston:555",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/274/page/galston:555/610d9181de82c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:555~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:555~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/274"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/275",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 276"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/275/page/galston:314",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/275/page/galston:314/610d91830e1ad",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:314~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:314~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/275"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/276",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 277"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/276/page/galston:554",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/276/page/galston:554/610d9184331c8",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:554~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:554~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/276"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/277",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 278"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/277/page/galston:313",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/277/page/galston:313/610d918565242",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:313~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:313~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/277"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/278",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 279"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/278/page/galston:553",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/278/page/galston:553/610d918689c38",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:553~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:553~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/278"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/279",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 280"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/279/page/galston:312",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/279/page/galston:312/610d9187af631",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:312~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:312~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/279"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/280",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 281"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/280/page/galston:552",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/280/page/galston:552/610d9188d920c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:552~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:552~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/280"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/281",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 282"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/281/page/galston:311",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/281/page/galston:311/610d918a12662",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:311~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:311~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/281"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/282",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 283"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/282/page/galston:551",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/282/page/galston:551/610d918b39b70",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:551~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:551~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/282"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/283",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 284"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/283/page/galston:310",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/283/page/galston:310/610d918c7060c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:310~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:310~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/283"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/284",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 285"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/284/page/galston:550",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/284/page/galston:550/610d918dafb65",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:550~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:550~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/284"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/285",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 286"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/285/page/galston:309",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/285/page/galston:309/610d918edf4bd",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:309~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:309~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/285"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/286",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 287"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/286/page/galston:549",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/286/page/galston:549/610d91901ee53",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:549~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:549~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/286"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/287",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 288"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/287/page/galston:308",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/287/page/galston:308/610d919154bff",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:308~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:308~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/287"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/288",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 289"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/288/page/galston:548",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/288/page/galston:548/610d919274894",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:548~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:548~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/288"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/289",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 290"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/289/page/galston:307",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/289/page/galston:307/610d9193a327e",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:307~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:307~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/289"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/290",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 291"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/290/page/galston:547",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/290/page/galston:547/610d9194e5613",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:547~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:547~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/290"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/291",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 292"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/291/page/galston:306",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/291/page/galston:306/610d91962b4e9",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:306~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:306~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/291"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/292",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 293"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/292/page/galston:546",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/292/page/galston:546/610d919758af7",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:546~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:546~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/292"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/293",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 294"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/293/page/galston:305",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/293/page/galston:305/610d9198909bc",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:305~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:305~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/293"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/294",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 295"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/294/page/galston:545",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/294/page/galston:545/610d9199b838f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:545~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:545~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/294"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/295",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 296"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/295/page/galston:304",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/295/page/galston:304/610d919add931",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:304~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:304~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/295"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/296",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 297"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/296/page/galston:544",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/296/page/galston:544/610d919c23890",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:544~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:544~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/296"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/297",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 298"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/297/page/galston:303",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/297/page/galston:303/610d919d49a50",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:303~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:303~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/297"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/298",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 299"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/298/page/galston:543",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/298/page/galston:543/610d919e79f3a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:543~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:543~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/298"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/299",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 300"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/299/page/galston:302",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/299/page/galston:302/610d919faed2b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:302~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:302~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/299"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/300",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 301"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/300/page/galston:542",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/300/page/galston:542/610d91a0d7a86",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:542~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:542~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/300"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/301",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 302"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/301/page/galston:301",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/301/page/galston:301/610d91a21aa9c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:301~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:301~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/301"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/302",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 303"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/302/page/galston:541",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/302/page/galston:541/610d91a34b559",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:541~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:541~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/302"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/303",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 304"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/303/page/galston:300",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/303/page/galston:300/610d91a47a5e6",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:300~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:300~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/303"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/304",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 305"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/304/page/galston:540",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/304/page/galston:540/610d91a5a1e08",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:540~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:540~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/304"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/305",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 306"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/305/page/galston:299",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/305/page/galston:299/610d91a6ce693",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:299~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:299~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/305"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/306",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 307"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/306/page/galston:539",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/306/page/galston:539/610d91a7f00c0",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:539~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:539~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/306"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/307",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 308"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/307/page/galston:298",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/307/page/galston:298/610d91a92b59b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:298~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:298~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/307"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/308",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 309"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/308/page/galston:538",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/308/page/galston:538/610d91aa58662",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:538~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:538~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/308"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/309",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 310"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/309/page/galston:297",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/309/page/galston:297/610d91ab6e5bd",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:297~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:297~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/309"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/310",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 311"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/310/page/galston:537",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/310/page/galston:537/610d91ac950ce",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:537~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:537~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/310"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/311",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 312"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/311/page/galston:296",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/311/page/galston:296/610d91adb913f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:296~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:296~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/311"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/312",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 313"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/312/page/galston:536",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/312/page/galston:536/610d91aeea621",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:536~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:536~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/312"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/313",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 314"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/313/page/galston:295",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/313/page/galston:295/610d91b018a55",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:295~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:295~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/313"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/314",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 315"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/314/page/galston:535",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/314/page/galston:535/610d91b14ac44",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:535~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:535~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/314"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/315",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 316"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/315/page/galston:294",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/315/page/galston:294/610d91b27a68c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:294~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:294~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/315"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/316",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 317"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/316/page/galston:534",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/316/page/galston:534/610d91b3a0099",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:534~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:534~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/316"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/317",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 318"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/317/page/galston:293",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/317/page/galston:293/610d91b4bcae8",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:293~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:293~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/317"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/318",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 319"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/318/page/galston:533",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/318/page/galston:533/610d91b5ede02",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:533~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:533~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/318"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/319",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 320"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/319/page/galston:292",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/319/page/galston:292/610d91b7207b2",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:292~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:292~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/319"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/320",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 321"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/320/page/galston:532",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/320/page/galston:532/610d91b844907",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:532~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:532~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/320"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/321",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 322"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/321/page/galston:291",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/321/page/galston:291/610d91b97ba17",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:291~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:291~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/321"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/322",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 323"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/322/page/galston:531",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/322/page/galston:531/610d91baaca98",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:531~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:531~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/322"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/323",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 324"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/323/page/galston:290",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/323/page/galston:290/610d91bbda92c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:290~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:290~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/323"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/324",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 325"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/324/page/galston:530",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/324/page/galston:530/610d91bd17c34",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:530~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:530~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/324"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/325",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 326"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/325/page/galston:289",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/325/page/galston:289/610d91be46d67",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:289~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:289~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/325"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/326",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 327"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/326/page/galston:529",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/326/page/galston:529/610d91bf6d418",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:529~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:529~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/326"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/327",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 328"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/327/page/galston:288",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/327/page/galston:288/610d91c095e5e",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:288~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:288~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/327"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/328",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 329"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/328/page/galston:528",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/328/page/galston:528/610d91c1b711d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:528~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:528~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/328"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/329",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 330"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/329/page/galston:287",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/329/page/galston:287/610d91c2de31a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:287~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:287~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/329"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/330",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 331"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/330/page/galston:527",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/330/page/galston:527/610d91c410ebd",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:527~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:527~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/330"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/331",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 332"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/331/page/galston:286",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/331/page/galston:286/610d91c5302a9",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:286~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:286~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/331"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/332",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 333"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/332/page/galston:526",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/332/page/galston:526/610d91c657ab1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:526~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:526~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/332"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/333",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 334"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/333/page/galston:285",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/333/page/galston:285/610d91c784e81",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:285~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:285~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/333"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/334",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 335"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/334/page/galston:525",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/334/page/galston:525/610d91c8b6d3e",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:525~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:525~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/334"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/335",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 336"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/335/page/galston:284",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/335/page/galston:284/610d91c9d8dd0",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:284~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:284~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/335"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/336",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 337"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/336/page/galston:524",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/336/page/galston:524/610d91cb09aca",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:524~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:524~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/336"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/337",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 338"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/337/page/galston:283",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/337/page/galston:283/610d91cc34ff7",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:283~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:283~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/337"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/338",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 339"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/338/page/galston:523",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/338/page/galston:523/610d91cd52a68",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:523~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:523~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/338"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/339",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 340"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/339/page/galston:282",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/339/page/galston:282/610d91ce87544",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:282~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:282~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/339"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/340",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 341"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/340/page/galston:522",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/340/page/galston:522/610d91cfaed87",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:522~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:522~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/340"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/341",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 342"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/341/page/galston:281",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/341/page/galston:281/610d91d0c9b8e",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:281~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:281~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/341"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/342",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 343"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/342/page/galston:521",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/342/page/galston:521/610d91d1e8bec",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:521~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:521~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/342"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/343",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 344"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/343/page/galston:280",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/343/page/galston:280/610d91d313dbc",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:280~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:280~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/343"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/344",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 345"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/344/page/galston:520",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/344/page/galston:520/610d91d4360b9",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:520~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:520~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/344"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/345",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 346"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/345/page/galston:279",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/345/page/galston:279/610d91d569403",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:279~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:279~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/345"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/346",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 347"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/346/page/galston:519",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/346/page/galston:519/610d91d6a3d32",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:519~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:519~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/346"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/347",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 348"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/347/page/galston:278",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/347/page/galston:278/610d91d7cdae6",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:278~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:278~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/347"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/348",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 349"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/348/page/galston:518",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/348/page/galston:518/610d91d901ccc",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:518~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:518~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/348"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/349",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 350"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/349/page/galston:277",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/349/page/galston:277/610d91da2e2ec",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:277~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:277~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/349"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/350",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 351"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/350/page/galston:517",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/350/page/galston:517/610d91db65f39",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:517~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:517~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/350"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/351",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 352"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/351/page/galston:276",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/351/page/galston:276/610d91dc9ad62",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:276~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:276~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/351"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/352",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 353"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/352/page/galston:516",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/352/page/galston:516/610d91ddd053b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:516~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:516~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/352"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/353",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 354"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/353/page/galston:275",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/353/page/galston:275/610d91df125b4",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:275~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:275~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/353"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/354",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 355"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/354/page/galston:515",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/354/page/galston:515/610d91e042386",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:515~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:515~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/354"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/355",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 356"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/355/page/galston:274",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/355/page/galston:274/610d91e175b29",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:274~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:274~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/355"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/356",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 357"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/356/page/galston:514",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/356/page/galston:514/610d91e2a68aa",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:514~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:514~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/356"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/357",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 358"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/357/page/galston:273",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/357/page/galston:273/610d91e3ce684",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:273~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:273~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/357"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/358",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 359"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/358/page/galston:513",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/358/page/galston:513/610d91e4f3f0d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:513~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:513~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/358"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/359",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 360"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/359/page/galston:272",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/359/page/galston:272/610d91e6237f7",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:272~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:272~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/359"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/360",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 361"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/360/page/galston:512",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/360/page/galston:512/610d91e747184",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:512~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:512~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/360"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/361",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 362"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/361/page/galston:271",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/361/page/galston:271/610d91e86ea7a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:271~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:271~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/361"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/362",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 363"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/362/page/galston:511",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/362/page/galston:511/610d91e99a509",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:511~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:511~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/362"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/363",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 364"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/363/page/galston:270",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/363/page/galston:270/610d91eab81dc",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:270~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:270~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/363"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/364",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 365"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/364/page/galston:510",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/364/page/galston:510/610d91ebd71be",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:510~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:510~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/364"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/365",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 366"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/365/page/galston:269",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/365/page/galston:269/610d91ed08608",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:269~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:269~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/365"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/366",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 367"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/366/page/galston:509",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/366/page/galston:509/610d91ee2b918",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:509~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:509~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/366"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/367",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 368"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/367/page/galston:268",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/367/page/galston:268/610d91ef554bc",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:268~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:268~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/367"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/368",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 369"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/368/page/galston:508",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/368/page/galston:508/610d91f084993",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:508~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:508~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/368"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/369",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 370"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/369/page/galston:267",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/369/page/galston:267/610d91f1a25e1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:267~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:267~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/369"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/370",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 371"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/370/page/galston:507",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/370/page/galston:507/610d91f2c731c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:507~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:507~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/370"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/371",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 372"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/371/page/galston:266",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/371/page/galston:266/610d91f40302d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:266~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:266~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/371"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/372",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 373"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/372/page/galston:506",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/372/page/galston:506/610d91f52d007",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:506~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:506~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/372"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/373",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 374"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/373/page/galston:265",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/373/page/galston:265/610d91f65e13f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:265~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:265~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/373"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/374",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 375"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/374/page/galston:505",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/374/page/galston:505/610d91f78fabb",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:505~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:505~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/374"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/375",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 376"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/375/page/galston:264",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/375/page/galston:264/610d91f8bb3ef",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:264~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:264~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/375"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/376",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 377"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/376/page/galston:504",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/376/page/galston:504/610d91f9dcf9c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:504~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:504~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/376"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/377",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 378"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/377/page/galston:263",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/377/page/galston:263/610d91fb11f34",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:263~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:263~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/377"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/378",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 379"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/378/page/galston:503",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/378/page/galston:503/610d91fc3d42d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:503~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:503~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/378"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/379",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 380"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/379/page/galston:262",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/379/page/galston:262/610d91fd5c8ef",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:262~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:262~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/379"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/380",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 381"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/380/page/galston:502",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/380/page/galston:502/610d91fe8d2ee",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:502~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:502~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/380"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/381",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 382"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/381/page/galston:261",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/381/page/galston:261/610d91ffb660f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:261~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:261~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/381"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/382",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 383"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/382/page/galston:501",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/382/page/galston:501/610d9200d105a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:501~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:501~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/382"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/383",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 384"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/383/page/galston:260",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/383/page/galston:260/610d9201f3972",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:260~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:260~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/383"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/384",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 385"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/384/page/galston:500",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/384/page/galston:500/610d9203288f2",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:500~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:500~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/384"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/385",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 386"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/385/page/galston:259",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/385/page/galston:259/610d92044c7e6",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:259~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:259~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/385"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/386",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 387"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/386/page/galston:499",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/386/page/galston:499/610d920578619",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:499~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:499~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/386"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/387",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 388"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/387/page/galston:258",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/387/page/galston:258/610d92069ebdd",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:258~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:258~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/387"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/388",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 389"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/388/page/galston:498",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/388/page/galston:498/610d9207c2599",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:498~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:498~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/388"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/389",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 390"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/389/page/galston:257",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/389/page/galston:257/610d9208e9f2d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:257~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:257~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/389"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/390",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 391"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/390/page/galston:497",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/390/page/galston:497/610d920a12e1e",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:497~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:497~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/390"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/391",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 392"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/391/page/galston:256",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/391/page/galston:256/610d920b3ddd3",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:256~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:256~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/391"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/392",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 393"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/392/page/galston:496",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/392/page/galston:496/610d920c6dabd",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:496~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:496~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/392"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/393",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 394"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/393/page/galston:255",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/393/page/galston:255/610d920d99cd4",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:255~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:255~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/393"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/394",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 395"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/394/page/galston:495",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/394/page/galston:495/610d920ec3b1b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:495~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:495~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/394"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/395",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 396"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/395/page/galston:217",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/395/page/galston:217/610d920fe9b9c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:217~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:217~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/395"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/396",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 397"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/396/page/galston:494",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/396/page/galston:494/610d9211190c1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:494~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:494~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/396"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/397",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 398"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/397/page/galston:254",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/397/page/galston:254/610d921241812",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:254~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:254~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/397"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/398",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 399"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/398/page/galston:216",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/398/page/galston:216/610d921368118",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:216~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:216~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/398"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/399",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 400"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/399/page/galston:253",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/399/page/galston:253/610d92148f9fd",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:253~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:253~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/399"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/400",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 401"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/400/page/galston:493",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/400/page/galston:493/610d9215c0ae5",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:493~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:493~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/400"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/401",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 402"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/401/page/galston:215",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/401/page/galston:215/610d9216ec5d5",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:215~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:215~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/401"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/402",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 403"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/402/page/galston:180",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/402/page/galston:180/610d92181a175",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:180~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:180~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/402"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/403",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 404"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/403/page/galston:252",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/403/page/galston:252/610d921944e90",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:252~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:252~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/403"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/404",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 405"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/404/page/galston:492",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/404/page/galston:492/610d921a642f8",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:492~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:492~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/404"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/405",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 406"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/405/page/galston:214",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/405/page/galston:214/610d921b87e1e",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:214~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:214~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/405"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/406",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 407"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/406/page/galston:491",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/406/page/galston:491/610d921cc3938",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:491~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:491~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/406"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/407",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 408"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/407/page/galston:251",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/407/page/galston:251/610d921ddbca7",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:251~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:251~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/407"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/408",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 409"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/408/page/galston:490",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/408/page/galston:490/610d921f0fe20",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:490~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:490~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/408"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/409",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 410"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/409/page/galston:213",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/409/page/galston:213/610d922036825",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:213~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:213~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/409"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/410",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 411"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/410/page/galston:489",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/410/page/galston:489/610d92215be47",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:489~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:489~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/410"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/411",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 412"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/411/page/galston:250",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/411/page/galston:250/610d92227c94c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:250~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:250~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/411"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/412",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 413"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/412/page/galston:488",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/412/page/galston:488/610d9223a97df",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:488~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:488~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/412"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/413",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 414"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/413/page/galston:212",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/413/page/galston:212/610d9224d9919",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:212~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:212~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/413"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/414",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 415"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/414/page/galston:487",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/414/page/galston:487/610d9225f2ae6",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:487~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:487~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/414"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/415",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 416"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/415/page/galston:249",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/415/page/galston:249/610d922724f12",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:249~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:249~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/415"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/416",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 417"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/416/page/galston:486",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/416/page/galston:486/610d9228494cc",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:486~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:486~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/416"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/417",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 418"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/417/page/galston:211",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/417/page/galston:211/610d92296b140",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:211~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:211~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/417"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/418",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 419"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/418/page/galston:485",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/418/page/galston:485/610d922a9665f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:485~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:485~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/418"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/419",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 420"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/419/page/galston:248",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/419/page/galston:248/610d922bb79fe",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:248~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:248~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/419"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/420",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 421"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/420/page/galston:484",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/420/page/galston:484/610d922cd4426",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:484~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:484~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/420"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/421",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 422"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/421/page/galston:210",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/421/page/galston:210/610d922e049f1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:210~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:210~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/421"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/422",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 423"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/422/page/galston:483",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/422/page/galston:483/610d922f31794",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:483~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:483~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/422"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/423",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 424"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/423/page/galston:247",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/423/page/galston:247/610d92305d81c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:247~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:247~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/423"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/424",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 425"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/424/page/galston:482",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/424/page/galston:482/610d923182709",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:482~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:482~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/424"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/425",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 426"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/425/page/galston:209",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/425/page/galston:209/610d9232a084e",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:209~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:209~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/425"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/426",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 427"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/426/page/galston:481",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/426/page/galston:481/610d9233c12f4",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:481~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:481~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/426"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/427",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 428"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/427/page/galston:246",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/427/page/galston:246/610d9234f0c20",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:246~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:246~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/427"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/428",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 429"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/428/page/galston:480",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/428/page/galston:480/610d923625e0f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:480~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:480~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/428"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/429",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 430"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/429/page/galston:208",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/429/page/galston:208/610d923745262",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:208~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:208~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/429"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/430",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 431"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/430/page/galston:479",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/430/page/galston:479/610d9238687ef",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:479~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:479~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/430"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/431",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 432"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/431/page/galston:245",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/431/page/galston:245/610d92398556b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:245~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:245~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/431"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/432",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 433"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/432/page/galston:478",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/432/page/galston:478/610d923aa947f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:478~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:478~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/432"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/433",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 434"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/433/page/galston:207",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/433/page/galston:207/610d923bd38ac",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:207~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:207~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/433"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/434",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 435"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/434/page/galston:477",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/434/page/galston:477/610d923d0c0f8",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:477~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:477~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/434"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/435",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 436"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/435/page/galston:244",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/435/page/galston:244/610d923e291ba",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:244~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:244~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/435"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/436",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 437"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/436/page/galston:476",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/436/page/galston:476/610d923f43331",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:476~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:476~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/436"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/437",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 438"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/437/page/galston:206",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/437/page/galston:206/610d924063359",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:206~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:206~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/437"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/438",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 439"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/438/page/galston:475",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/438/page/galston:475/610d92418c29c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:475~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:475~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/438"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/439",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 440"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/439/page/galston:243",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/439/page/galston:243/610d9242b50a5",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:243~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:243~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/439"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/440",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 441"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/440/page/galston:474",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/440/page/galston:474/610d9243d859b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:474~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:474~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/440"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/441",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 442"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/441/page/galston:205",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/441/page/galston:205/610d924505b21",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:205~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:205~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/441"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/442",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 443"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/442/page/galston:473",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/442/page/galston:473/610d92462a856",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:473~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:473~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/442"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/443",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 444"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/443/page/galston:242",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/443/page/galston:242/610d924744dd4",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:242~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:242~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/443"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/444",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 445"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/444/page/galston:472",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/444/page/galston:472/610d92487353b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:472~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:472~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/444"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/445",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 446"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/445/page/galston:204",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/445/page/galston:204/610d9249a8202",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:204~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:204~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/445"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/446",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 447"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/446/page/galston:471",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/446/page/galston:471/610d924adee81",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:471~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:471~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/446"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/447",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 448"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/447/page/galston:241",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/447/page/galston:241/610d924c1f8c1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:241~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:241~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/447"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/448",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 449"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/448/page/galston:470",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/448/page/galston:470/610d924d4f1b9",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:470~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:470~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/448"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/449",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 450"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/449/page/galston:203",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/449/page/galston:203/610d924e7ae97",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:203~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:203~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/449"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/450",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 451"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/450/page/galston:469",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/450/page/galston:469/610d924fa66aa",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:469~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:469~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/450"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/451",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 452"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/451/page/galston:240",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/451/page/galston:240/610d9250e39df",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:240~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:240~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/451"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/452",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 453"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/452/page/galston:468",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/452/page/galston:468/610d9252217dc",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:468~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:468~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/452"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/453",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 454"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/453/page/galston:202",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/453/page/galston:202/610d92535385c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:202~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:202~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/453"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/454",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 455"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/454/page/galston:467",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/454/page/galston:467/610d9254869b4",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:467~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:467~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/454"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/455",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 456"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/455/page/galston:239",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/455/page/galston:239/610d9255ae2db",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:239~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:239~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/455"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/456",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 457"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/456/page/galston:466",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/456/page/galston:466/610d9256d9702",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:466~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:466~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/456"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/457",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 458"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/457/page/galston:201",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/457/page/galston:201/610d925817485",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:201~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:201~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/457"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/458",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 459"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/458/page/galston:465",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/458/page/galston:465/610d925946c14",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:465~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:465~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/458"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/459",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 460"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/459/page/galston:238",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/459/page/galston:238/610d925a70e80",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:238~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:238~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/459"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/460",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 461"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/460/page/galston:464",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/460/page/galston:464/610d925b9bde5",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:464~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:464~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/460"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/461",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 462"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/461/page/galston:200",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/461/page/galston:200/610d925ccc8d9",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:200~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:200~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/461"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/462",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 463"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/462/page/galston:463",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/462/page/galston:463/610d925e044e8",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:463~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:463~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/462"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/463",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 464"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/463/page/galston:237",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/463/page/galston:237/610d925f295f5",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:237~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:237~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/463"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/464",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 465"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/464/page/galston:462",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/464/page/galston:462/610d926059a9f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:462~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:462~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/464"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/465",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 466"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/465/page/galston:199",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/465/page/galston:199/610d92618b3dd",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:199~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:199~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/465"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/466",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 467"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/466/page/galston:461",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/466/page/galston:461/610d9262c1216",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:461~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:461~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/466"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/467",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 468"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/467/page/galston:236",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/467/page/galston:236/610d92632de14",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:236~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:236~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/467"
+            }
+          ]
+        }
+      ],
+      "annotations": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/467/annotations",
+          "type": "AnnotationPage",
+          "label": "Studienbuch: page 468",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/467/annotations/1",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "This tailpiece is printed at the end of the Studienbuch, and also appears in other publications by Bruno Cassirer."
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/467#xywh=1664,1120,4096,6272"
+            },
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/467/annotations/2",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "The motif depicts a man with a walking stick and carrying a basket on his back."
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/467#xywh=3880,3360,768,1136"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/468",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 469"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/468/page/galston:460",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/468/page/galston:460/610d92638ec88",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:460~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:460~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/468"
+            }
+          ]
+        }
+      ],
+      "annotations": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/468/annotations",
+          "type": "AnnotationPage",
+          "label": "Studienbuch: page 469",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/468/annotations/1",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Aphorism on Liszt - handwritten by Ferruccio Busoni"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/468#xywh=928,656,4064,7136"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/469",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 470"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/469/page/galston:198",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/469/page/galston:198/610d9263ef829",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:198~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:198~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/469"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/470",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 471"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/470/page/galston:459",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/470/page/galston:459/610d92645c52b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:459~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:459~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/470"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/471",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 472"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/471/page/galston:235",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/471/page/galston:235/610d9264bd35f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:235~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:235~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/471"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/472",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 473"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/472/page/galston:458",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/472/page/galston:458/610d926529c4f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:458~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:458~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/472"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/473",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 474"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/473/page/galston:197",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/473/page/galston:197/610d92658a7d4",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:197~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:197~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/473"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/474",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 475"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/474/page/galston:457",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/474/page/galston:457/610d9265eadd6",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:457~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:457~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/474"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/475",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 476"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/475/page/galston:234",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/475/page/galston:234/610d9266589cc",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:234~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:234~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/475"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/476",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 477"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/476/page/galston:456",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/476/page/galston:456/610d9266b90e3",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:456~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:456~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/476"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 478"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477/page/galston:196",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477/page/galston:196/610d9267259c2",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:196~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:196~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477"
+            }
+          ]
+        }
+      ],
+      "annotations": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477/annotations",
+          "type": "AnnotationPage",
+          "label": "Studienbuch: page 478",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477/annotations/1",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Concert Program - October 12, 1919"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477#xywh=1616,360,1488,1888"
+            },
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477/annotations/2",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Concert Program - October 19, 1919"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477#xywh=3536,384,2496,2096"
+            },
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477/annotations/3",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Concert Program - October 26, 1919"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477#xywh=1360,2464,2000,1584"
+            },
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477/annotations/4",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Concert Program - November 2, 1919"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477#xywh=3600,2552,2384,1744"
+            },
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477/annotations/5",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Concert Program - November 9, 1919"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477#xywh=1400,4432,2528,2144"
+            },
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477/annotations/6",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Concert Program - November 16, 1919"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477#xywh=3992,4432,1824,2080"
+            },
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477/annotations/7",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Concert Program - November 23, 1919"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477#xywh=1400,6584,2288,1488"
+            },
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477/annotations/8",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Concert Program - November 30, 1919"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/477#xywh=3864,6584,1904,1472"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 479"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/page/galston:455",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/page/galston:455/610d92678657d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:455~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:455~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478"
+            }
+          ]
+        }
+      ],
+      "annotations": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations",
+          "type": "AnnotationPage",
+          "label": "Studienbuch: page 479",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/1",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Concert Program - December 7, 1919"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478#xywh=496,312,2160,1440"
+            },
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/2",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Concert Program - December 14, 1919"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478#xywh=2848,280,2064,1632"
+            },
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/3",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Concert Program - January 4, 1920"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478#xywh=528,1760,2528,1616"
+            },
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/4",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Concert Program - January 11, 1920"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478#xywh=3160,1928,1760,1376"
+            },
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/5",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Concert Program - January 18, 1920"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478#xywh=528,3384,2736,1056"
+            },
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/6",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Concert Program - January 25, 1920"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478#xywh=3288,3296,1536,1040"
+            },
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/7",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Concert Program - February 1, 1920"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478#xywh=568,4600,2224,1216"
+            },
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/8",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Concert Program - February 8, 1920"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478#xywh=3152,4616,1696,1456"
+            },
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/9",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Concert Program - February 15, 1920"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478#xywh=432,6000,2288,1952"
+            },
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478/annotations/10",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Concert Program - February 22, 1920"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/478#xywh=2576,6032,2336,2064"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/479",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 480"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/479/page/galston:233",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/479/page/galston:233/610d9267e70ca",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:233~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:233~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/479"
+            }
+          ]
+        }
+      ],
+      "annotations" : [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/479/annotations",
+          "type": "AnnotationPage",
+          "label": "Studienbuch: page 480",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/479/annotations/1",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Concert Program - February 29, 1920"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/479#xywh=1392,288,2472,1528"
+            },
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/479/annotations/2",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Concert Program - March 7, 1920"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/479#xywh=3936,232,2056,1856"
+            },
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/479/annotations/3",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Concert Program - March 14, 1920"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/479#xywh=1428,2088,2344,1336"
+            },
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/479/annotations/4",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Concert Program - March 21, 1920"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/479#xywh=3996,2088,1864,1208"
+            },
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/479/annotations/5",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Concert Program - March 28, 1920"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/479#xywh=1404,3460,2416,1464"
+            },
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/479/annotations/6",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Concert Program - April 4, 1920"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/479#xywh=3908,3388,2064,1456"
+            },
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/479/annotations/7",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Concert Program - April 11, 1920"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/479#xywh=1540,5056,2088,1512"
+            },
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/479/annotations/8",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Concert Program - April 18, 1920"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/479#xywh=3860,5060,2056,1624"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/480",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 481"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/480/page/galston:454",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/480/page/galston:454/610d9268536fb",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:454~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:454~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/480"
+            }
+          ]
+        }
+      ],
+      "annotations": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/480/annotations",
+          "type": "AnnotationPage",
+          "label": "Studienbuch: page 481",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/480/annotations/1",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Concert Program - April 25, 1920"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/480#xywh=412,288,2136,1784"
+            },
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/480/annotations/2",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Concert Program - May 2, 1920"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/480#xywh=2716,320,2064,1432"
+            },
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/480/annotations/3",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Concert Program - May 9, 1920"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/480#xywh=484,2600,1960,2184"
+            },
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/480/annotations/4",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Concert Program - May 16, 1920"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/480#xywh=2632,2580,2256,2144"
+            },
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/480/annotations/5",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Concert Program - September 12, 1920"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/480#xywh=496,5072,1768,1104"
+            },
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/480/annotations/6",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Concert Program - September 26, 1920"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/480#xywh=2604,5080,2272,1336"
+            },
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/480/annotations/7",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Concert Program - October 10, 1920"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/480#xywh=412,6428,2104,1672"
+            },
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/480/annotations/8",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Concert Program - October 31, 1920"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/480#xywh=2632,6472,2216,1536"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/481",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 482"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/481/page/galston:195",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/481/page/galston:195/610d9268b420f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:195~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:195~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/481"
+            }
+          ]
+        }
+      ],
+      "annotations": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/481/annotations",
+          "type": "AnnotationPage",
+          "label": "Studienbuch: page 482",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/481/annotations/1",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Concert Program - November 21, 1920"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/481#xywh=1536,296,2448,1936"
+            },
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/481/annotations/2",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Concert Program - December 5, 1920"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/481#xywh=3928,328,2128,2976"
+            },
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/481/annotations/3",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Concert Program - January 16, 1921"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/481#xywh=1672,3024,2752,2560"
+            },
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/481/annotations/4",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Concert Program - January 30, 1921"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/481#xywh=4416,3312,1696,2176"
+            },
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/481/annotations/5",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Concert Program - February 13, 1921"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/481#xywh=1584,5728,2560,2256"
+            },
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/481/annotations/6",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Concert Program - February 20, 1921"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/481#xywh=4168,5672,1968,2400"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/482",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 483"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/482/page/galston:450",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/482/page/galston:450/610d926920445",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:450~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:450~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/482"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/483",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 484"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/483/page/galston:232",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/483/page/galston:232/610d926980ded",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:232~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:232~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/483"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/484",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 485"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/484/page/galston:449",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/484/page/galston:449/610d926ab5c20",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:449~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:449~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/484"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/485",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 486"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/485/page/galston:194",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/485/page/galston:194/610d926be5629",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:194~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:194~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/485"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/486",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 487"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/486/page/galston:220",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/486/page/galston:220/610d926d1f569",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:220~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:220~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/486"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/487",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 488"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/487/page/galston:231",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/487/page/galston:231/610d926e47dfd",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:231~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:231~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/487"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/488",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 489"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/488/page/galston:228",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/488/page/galston:228/610d926f6abf4",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:228~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:228~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/488"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/489",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 490"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/489/page/galston:193",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/489/page/galston:193/610d927097411",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:193~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:193~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/489"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/490",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 491"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/490/page/galston:453",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/490/page/galston:453/610d9271c35a1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:453~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:453~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/490"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/491",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 492"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/491/page/galston:230",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/491/page/galston:230/610d9272f33cf",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:230~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:230~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/491"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/492",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 493"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/492/page/galston:182",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/492/page/galston:182/610d9274262ba",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:182~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:182~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/492"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/493",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 494"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/493/page/galston:192",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/493/page/galston:192/610d927548d97",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:192~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:192~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/493"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/494",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 495"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/494/page/galston:452",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/494/page/galston:452/610d9276725cf",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:452~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:452~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/494"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/495",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 496"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/495/page/galston:229",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/495/page/galston:229/610d9277a88df",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:229~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:229~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/495"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/496",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 497"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/496/page/galston:451",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/496/page/galston:451/610d9278d18a4",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:451~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:451~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/496"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/497",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 498"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/497/page/galston:191",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/497/page/galston:191/610d927a14975",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:191~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:191~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/497"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/498",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 499"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/498/page/galston:712",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/498/page/galston:712/610d927a7579a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:712~datastream~JP2/full/full/0/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image/jpeg",
+                  "service": {
+                    "@id": "https://digital.lib.utk.edu/iiif/2/collections~islandora~object~galston:712~datastream~JP2",
+                    "@type": "http://iiif.io/api/image/2/context.json",
+                    "profile": "http://iiif.io/api/image/2/level2.json"
+                  }
+                }
+              ],
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/498"
+            }
+          ]
+        }
+      ],
+      "annotations": [
+        {
+          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/498/annotations",
+          "type": "AnnotationPage",
+          "label": "Studienbuch",
+          "items": [
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/498/annotations/1",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Spine title"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/498#xywh=1104,0,4184,4000"
+            },
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/498/annotations/2",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Spine detail"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/498#xywh=1600,6352,3100,1700"
+            },
+            {
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/498/annotations/3",
+              "type": "Annotation",
+              "motivation": "commenting",
+              "body": {
+                "type": "FragmentSelector",
+                "language": "en",
+                "value": "Studienbuch - Spine note, Extra ill copy"
+              },
+              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/498#xywh=2464,7352,1372,776"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "seeAlso": [
+    {
+      "id": "https://digital.lib.utk.edu/collections/islandora/object/galston%3A178/datastream/MODS",
+      "type": "Dataset",
+      "label": {
+        "en": [
+          "Bibliographic Description in MODS"
+        ]
+      },
+      "format": "application/xml",
+      "profile": "http://www.loc.gov/standards/mods/v3/mods-3-5.xsd"
+    }
+  ],
+  "behavior": [
+    "individuals"
+  ]
+}

--- a/iiif/studienbuch_not_paged.json
+++ b/iiif/studienbuch_not_paged.json
@@ -194,36 +194,36 @@
               ],
               "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/0"
             }
-          ]
-        }
-      ],
-      "annotations": [
-        {
-          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/0/annotations",
-          "type": "AnnotationPage",
-          "label": "Studienbuch",
-          "items": [
+          ],
+          "annotations": [
             {
-              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/0/annotations/1",
-              "type": "Annotation",
-              "motivation": "commenting",
-              "body": {
-                "type": "FragmentSelector",
-                "language": "en",
-                "value": "Studienbuch - Front Cover"
-              },
-              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/0#xywh=200,150,5150,8000"
-            },
-            {
-              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/0/annotations/2",
-              "type": "Annotation",
-              "motivation": "commenting",
-              "body": {
-                "type": "FragmentSelector",
-                "language": "en",
-                "value": "Studienbuch - Front cover detail"
-              },
-              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/0#xywh=2500,0,3000,2500"
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/0/annotations",
+              "type": "AnnotationPage",
+              "label": "Studienbuch",
+              "items": [
+                {
+                  "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/0/annotations/1",
+                  "type": "Annotation",
+                  "motivation": "commenting",
+                  "body": {
+                    "type": "FragmentSelector",
+                    "language": "en",
+                    "value": "Studienbuch - Front Cover"
+                  },
+                  "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/0#xywh=200,150,5150,8000"
+                },
+                {
+                  "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/0/annotations/2",
+                  "type": "Annotation",
+                  "motivation": "commenting",
+                  "body": {
+                    "type": "FragmentSelector",
+                    "language": "en",
+                    "value": "Studienbuch - Front cover detail"
+                  },
+                  "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/0#xywh=2500,0,3000,2500"
+                }
+              ]
             }
           ]
         }
@@ -264,25 +264,25 @@
               ],
               "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/1"
             }
-          ]
-        }
-      ],
-      "annotations": [
-        {
-          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/1/annotations",
-          "type": "AnnotationPage",
-          "label": "Studienbuch",
-          "items": [
+          ],
+          "annotations": [
             {
-              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/1/annotations/1",
-              "type": "Annotation",
-              "motivation": "commenting",
-              "body": {
-                "type": "FragmentSelector",
-                "language": "en",
-                "value": "Studienbuch - Inside cover"
-              },
-              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/1#xywh=4644,7616,1330,596"
+              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/1/annotations",
+              "type": "AnnotationPage",
+              "label": "Studienbuch",
+              "items": [
+                {
+                  "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/1/annotations/1",
+                  "type": "Annotation",
+                  "motivation": "commenting",
+                  "body": {
+                    "type": "FragmentSelector",
+                    "language": "en",
+                    "value": "Studienbuch - Inside cover"
+                  },
+                  "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/1#xywh=4644,7616,1330,596"
+                }
+              ]
             }
           ]
         }
@@ -6421,37 +6421,6 @@
             }
           ]
         }
-      ],
-      "annotations": [
-        {
-          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/157/annotations",
-          "type": "AnnotationPage",
-          "label": "Studienbuch: page 158",
-          "items": [
-            {
-              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/157/annotations/1",
-              "type": "Annotation",
-              "motivation": "commenting",
-              "body": {
-                "type": "FragmentSelector",
-                "language": "en",
-                "value": "Galston makes four editorial changes in the Chopin section."
-              },
-              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/157#xywh=1312,288,4640,7712"
-            },
-            {
-              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/157/annotations/2",
-              "type": "Annotation",
-              "motivation": "commenting",
-              "body": {
-                "type": "FragmentSelector",
-                "language": "en",
-                "value": "Handwritten note in Chopin section"
-              },
-              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/157#xywh=1544,5816,4464,624"
-            }
-          ]
-        }
       ]
     },
     {
@@ -6608,26 +6577,6 @@
             }
           ]
         }
-      ],
-      "annotations": [
-        {
-          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/161/annotations",
-          "type": "AnnotationPage",
-          "label": "Studienbuch: page 162",
-          "items": [
-            {
-              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/161/annotations/1",
-              "type": "Annotation",
-              "motivation": "commenting",
-              "body": {
-                "type": "FragmentSelector",
-                "language": "en",
-                "value": "x Vor-Parallestudium (Transponieren durch mehrere Tonarten) zum Finale des hmoll Sonate!\n=======\nx Pre-parallel study (transposition through several keys) to the final of the b-minor sonata!"
-              },
-              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/161#xywh=1632,2288,4160,1424"
-            }
-          ]
-        }
       ]
     },
     {
@@ -6745,28 +6694,6 @@
             }
           ]
         }
-      ],
-      "annotations": [
-        [
-          {
-            "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/164/annotations",
-            "type": "AnnotationPage",
-            "label": "Studienbuch: page 165",
-            "items": [
-              {
-                "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/164/annotations/1",
-                "type": "Annotation",
-                "motivation": "commenting",
-                "body": {
-                  "type": "FragmentSelector",
-                  "language": "en",
-                  "value": "Dieses Studienmaterial mit den Komplexen der Etüde Op 10 No 2 amoll kombinieren. Technische Verwandtschaft\nx x x\n============\nCombine this study material with the issues related to the étude Op 10 No 2 in a-minor. Technical relationship.\nx x x"
-                },
-                "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/164#xywh=320,3488,4256,1248"
-              }
-            ]
-          }
-        ]
       ]
     },
     {
@@ -6803,26 +6730,6 @@
                 }
               ],
               "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/165"
-            }
-          ]
-        }
-      ],
-      "annotations": [
-        {
-          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/165/annotations",
-          "type": "AnnotationPage",
-          "label": "Studienbuch: page 166",
-          "items": [
-            {
-              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/165/annotations/1",
-              "type": "Annotation",
-              "motivation": "commenting",
-              "body": {
-                "type": "FragmentSelector",
-                "language": "en",
-                "value": "Die charakteristischen technischen Laufgruppen (z.B. Takte 1-2, 29-32 u.s.w.) zu fortlaufenden Fingerüberungen durch alle 12 Tonarten benützen: Zur Befestigung und Ausbildung des 6 Pianistensinns des Distanzgefühls (in Spannung und Sprung) . \nx x x\n=======\nUse the characteristic technical runs (e.g. measures 1-2, 29-32 etc.) for extended fingering practice through all 12 keys: For the development and establishment of the 6th pianistic sense of distance (in tension and leap).\nx x x"
-              },
-              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/165#xywh=1712,4864,4160,1440"
             }
           ]
         }
@@ -8578,26 +8485,6 @@
                 }
               ],
               "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/210"
-            }
-          ]
-        }
-      ],
-      "annotations": [
-        {
-          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/210/annotations",
-          "type": "AnnotationPage",
-          "label": "Studienbuch: page 211",
-          "items": [
-            {
-              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/210/annotations/1",
-              "type": "Annotation",
-              "motivation": "commenting",
-              "body": {
-                "type": "FragmentSelector",
-                "language": "en",
-                "value": "The piece appears on page 210 in the Studienbuch's Appendices (Anhang). It was also published in Ferruccio Busoni's 1922 book, Von der Einheit der Musik (Of the Unity of Music). and was reportedly included in Busoni's Zurich program of April 1916."
-              },
-              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/210#xywh=272,1328,3712,5440"
             }
           ]
         }
@@ -18666,37 +18553,6 @@
             }
           ]
         }
-      ],
-      "annotations": [
-        {
-          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/467/annotations",
-          "type": "AnnotationPage",
-          "label": "Studienbuch: page 468",
-          "items": [
-            {
-              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/467/annotations/1",
-              "type": "Annotation",
-              "motivation": "commenting",
-              "body": {
-                "type": "FragmentSelector",
-                "language": "en",
-                "value": "This tailpiece is printed at the end of the Studienbuch, and also appears in other publications by Bruno Cassirer."
-              },
-              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/467#xywh=1664,1120,4096,6272"
-            },
-            {
-              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/467/annotations/2",
-              "type": "Annotation",
-              "motivation": "commenting",
-              "body": {
-                "type": "FragmentSelector",
-                "language": "en",
-                "value": "The motif depicts a man with a walking stick and carrying a basket on his back."
-              },
-              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/467#xywh=3880,3360,768,1136"
-            }
-          ]
-        }
       ]
     },
     {
@@ -18733,26 +18589,6 @@
                 }
               ],
               "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/468"
-            }
-          ]
-        }
-      ],
-      "annotations": [
-        {
-          "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/468/annotations",
-          "type": "AnnotationPage",
-          "label": "Studienbuch: page 469",
-          "items": [
-            {
-              "id": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/468/annotations/1",
-              "type": "Annotation",
-              "motivation": "commenting",
-              "body": {
-                "type": "FragmentSelector",
-                "language": "en",
-                "value": "Aphorism on Liszt - handwritten by Ferruccio Busoni"
-              },
-              "target": "https://digital.lib.utk.edu/assemble/manifest/galston/178/canvas/468#xywh=928,656,4064,7136"
             }
           ]
         }


### PR DESCRIPTION
# What does this do?

EXHIBIT-93 can't be merged because we have a problem where Mirador doesn't know whether the canvas being loaded is on the left or right when a manifest has the behavior of paged. This helps us get around this problem by making the manifest that concert programs uses to not be paged.

# How can I test this?

I've checked out this branch on the server so that the corresponding branch that goes with EXHIBIT-93 is using this until we merge so we can test.