### PR TITLE
Address DIGITAL-1308: Remove items without Releases.

### DIFF
--- a/iiif/collections/rfta_completed.json
+++ b/iiif/collections/rfta_completed.json
@@ -569,15 +569,6 @@
       }
     },
     {
-      "id": "https://digital.lib.utk.edu/assemble/manifest/rfta/93",
-      "type": "Manifest",
-      "label": {
-        "none": [
-          "rfta:93"
-        ]
-      }
-    },
-    {
       "id": "https://digital.lib.utk.edu/assemble/manifest/rfta/94",
       "type": "Manifest",
       "label": {

--- a/iiif/collections/rfta_completed.json
+++ b/iiif/collections/rfta_completed.json
@@ -1001,15 +1001,6 @@
       }
     },
     {
-      "id": "https://digital.lib.utk.edu/assemble/manifest/rfta/145",
-      "type": "Manifest",
-      "label": {
-        "none": [
-          "rfta:145"
-        ]
-      }
-    },
-    {
       "id": "https://digital.lib.utk.edu/assemble/manifest/rfta/146",
       "type": "Manifest",
       "label": {

--- a/iiif/collections/rfta_completed.json
+++ b/iiif/collections/rfta_completed.json
@@ -632,15 +632,6 @@
       }
     },
     {
-      "id": "https://digital.lib.utk.edu/assemble/manifest/rfta/102",
-      "type": "Manifest",
-      "label": {
-        "none": [
-          "rfta:102"
-        ]
-      }
-    },
-    {
       "id": "https://digital.lib.utk.edu/assemble/manifest/rfta/103",
       "type": "Manifest",
       "label": {

--- a/iiif/collections/rfta_completed.json
+++ b/iiif/collections/rfta_completed.json
@@ -380,15 +380,6 @@
       }
     },
     {
-      "id": "https://digital.lib.utk.edu/assemble/manifest/rfta/65",
-      "type": "Manifest",
-      "label": {
-        "none": [
-          "rfta:65"
-        ]
-      }
-    },
-    {
       "id": "https://digital.lib.utk.edu/assemble/manifest/rfta/66",
       "type": "Manifest",
       "label": {

--- a/iiif/collections/rfta_completed.json
+++ b/iiif/collections/rfta_completed.json
@@ -1215,15 +1215,6 @@
           "rfta:167"
         ]
       }
-    },
-    {
-      "id": "https://digital.lib.utk.edu/assemble/manifest/rfta/170",
-      "type": "Manifest",
-      "label": {
-        "none": [
-          "rfta:170"
-        ]
-      }
     }
   ]
 }

--- a/iiif/collections/rfta_completed.json
+++ b/iiif/collections/rfta_completed.json
@@ -1197,6 +1197,15 @@
           "rfta:167"
         ]
       }
+    },
+    {
+      "id": "https://digital.lib.utk.edu/assemble/manifest/rfta/170",
+      "type": "Manifest",
+      "label": {
+        "none": [
+          "rfta:170"
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
## What Does This Do

Removes objects without a release from the collection manifest for rfta.

## Why Does This Matter

Currently, these show up in a canopy build, but don't have anything other than metadata.  Let's remove them until we are able to release.

## Ways I could Test

1. Test in your favorite validator. (You may need to change the id to wherever you host).
2. Read over the changes 
3. Compare with the object in Islandora.
4. Ask questions

## How many viewers are needed pre-merge.

One.