### PR TITLE
Add dynamic manifests used Galston to static.

### DIFF
--- a/iiif/galston_1.json
+++ b/iiif/galston_1.json
@@ -1,0 +1,7096 @@
+{
+  "@context": [
+    "https:\/\/iiif.io\/api\/presentation\/3\/context.json"
+  ],
+  "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1",
+  "type": "Manifest",
+  "label": {
+    "en": [
+      "Programme zum Zyklus von vierzig Konzerten"
+    ]
+  },
+  "summary": {
+    "en": [
+      "Bound volume containing individual programs from Gottfried Galston's cycle of 40 historical recitals in Munich, Germany, between 1919 and 1921. Concerts occurred Sundays, typically at 4PM (the final concert was at 7:30PM). The programs assert that the concerts share the entirety of significant piano literature from the beginning to the present."
+    ]
+  },
+  "metadata": [
+    {
+      "label": {
+        "en": [
+          "Alternative Title"
+        ]
+      },
+      "value": {
+        "en": [
+          "Programs for a cycle of forty concerts"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Table of Contents"
+        ]
+      },
+      "value": {
+        "en": [
+          "Programm des ersten Vortrages (1. Zyklus ): Sonntag, 12. Oktober 1919  -- Programm des zweiten Vortrages (Zyklus I): Sonntag, 19. Oktober 1919 -- Programm des dritten Vortrages (Zyklus I): Sonntag, 26. Oktober 1919 -- \n        Programm des vierten Vortrages (Zyklus I) -- Programm des f\u00fcnften Vortrages (Zyklus I): Sonntag, 9. November 1919 -- Programm des sechsten Vortrages (Zyklus I): Sonntag, 16. November 1919 -- \n        Programm des siebenten Vortrages (Zyklus I): Sonntag, 23. November 1919 -- Programm des achten Vortrages (Zyklus I): Sonntag, 30. November 1919 -- Programm des neunten Vortrages (Zyklus I): Sonntag, 7. December 1919 -- \n        Programm des zehnten Vortrages (Zyklus I): Sonntag, 14. December 1919 -- Programm des ersten Vortrages (Zyklus II): Sonntag, 4. Januar 1920 -- Programm des zweiten Vortrages (Zyklus II): Sonntag, 11. Januar 1920 -- \n        Programm des dritten Vortrages (Zyklus II): Sonntag, 18. Januar 1920 -- Programm des vierten Vortrages (Zyklus II): Sonntag, 25. Januar 1920 -- Programm des f\u00fcnften Vortrages (Zyklus II): Sonntag, 1. Februar 1920 -- \n        Programm des sechsten Vortrages (Zyklus II): Sonntag, 8. Februar 1920 -- Programm des siebenten Vortrages (Zyklus II): Sonntag, 15. Februar 1920 -- Programm des achten Vortrages (Zyklus II): Sonntag, 22. Februar 1920 --\n        Programm des neunten Vortrages (Zyklus II): Sonntag, 29. Februar 1920 -- Programm des zehnten Vortrages (Zyklus II): Sonntag, 7. Marz 1920 -- Programm des ersten Vortrages (Zyklus III): Sonntag, 14. Marz 1920 -- \n        Programm des zweiten Vortrages (Zyklus III): Sonntag, 21. Marz 1920 -- Programm des dritten Vortrages (Zyklus III): Sonntag, 28. Marz 1920 -- Programm des vierten Vortrages (Zyklus III): Sonntag, 4. April 1920 --\n        Programm des f\u00fcnften Vortrages (Zyklus III): Sonntag, 11. April 1920 -- Programm des sechsten Vortrages (Zyklus III): Sonntag, 18. April 1920 -- Programm des siebenten Vortrages (Zyklus III): Sonntag, 25. April 1920 --\n        Programm des achten Vortrages (Zyklus III): Sonntag, 2. Mai 1920 -- Programm des neunten Vortrages (Zyklus III): Sonntag, 9. Mai 1920 -- Programm des zehnten (letzten) Vortrages (Zyklus III): Sonntag, 16. Mai 1920 --\n        Programm des ersten Vortrages (Zyklus IV) (31. Konzert): Sonntag, 12. September 1920 -- Programm des zweiten Vortrages (Zyklus IV) (32. Konzert): Sonntag, 26. September 1920 -- Programm des dritten Vortrages (Zyklus IV) (33. Konzert): Sonntag, 10. Oktober 1920 --\n        Programm des f\u00fcnften Vortrages (Zyklus IV) (35. Konzert): Sonntag, 21. November 1920 -- Programm des sechsten Vortrages (Zyklus IV) (36. Konzert): Sonntag, 5. Dezember 1920 -- Programm des siebenten Vortrages (Zyklus IV) (37. Konzert): Sonntag, 16. Januar 1921 --\n        Programm des achten Vortrages (Zyklus IV) (38. Konzert): Sonntag, 30. Januar 1921 -- Programm des neunten Vortrages (Zyklus IV) (39. Konzert): Sonntag, 13. Februar 1921 -- Programm des 40 (Letzen) Konzerts: Sonntag, 20. Februar 1921, 7 1\/2 Uhr p\u00fcnktlich\n    "
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Publication Date"
+        ]
+      },
+      "value": {
+        "en": [
+          "October 12, 1919-February 20, 1921",
+          "1919-10-12",
+          "1921-02-20"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Format"
+        ]
+      },
+      "value": {
+        "en": [
+          "books",
+          "concert programs"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Extent"
+        ]
+      },
+      "value": {
+        "en": [
+          "176 pages"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Subject"
+        ]
+      },
+      "value": {
+        "en": [
+          "Music",
+          "Piano music",
+          "Concert programs",
+          "Musical canon"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Description"
+        ]
+      },
+      "value": {
+        "en": [
+          "Bound volume containing individual programs from Gottfried Galston's cycle of 40 historical recitals in Munich, Germany, between 1919 and 1921. Concerts occurred Sundays, typically at 4PM (the final concert was at 7:30PM). The programs assert that the concerts share the entirety of significant piano literature from the beginning to the present."
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Language"
+        ]
+      },
+      "value": {
+        "en": [
+          "German"
+        ]
+      }
+    }
+  ],
+  "rights": "http:\/\/rightsstatements.org\/vocab\/NKC\/1.0\/",
+  "requiredStatement": {
+    "label": {
+      "en": [
+        "Provided by"
+      ]
+    },
+    "value": {
+      "en": [
+        "University of Tennessee, Knoxville. Libraries"
+      ]
+    }
+  },
+  "provider": [
+    {
+      "id": "https:\/\/www.lib.utk.edu\/about\/",
+      "type": "Agent",
+      "label": {
+        "en": [
+          "University of Tennessee, Knoxville. Libraries"
+        ]
+      },
+      "homepage": [
+        {
+          "id": "https:\/\/www.lib.utk.edu\/",
+          "type": "Text",
+          "label": {
+            "en": [
+              "University of Tennessee Libraries Homepage"
+            ]
+          },
+          "format": "text\/html"
+        }
+      ],
+      "logo": [
+        {
+          "id": "https:\/\/utkdigitalinitiatives.github.io\/iiif-level-0\/ut_libraries_centered\/full\/full\/0\/default.jpg",
+          "type": "Image",
+          "format": "image\/jpeg",
+          "width": 200,
+          "height": 200
+        }
+      ]
+    }
+  ],
+  "thumbnail": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/collections\/islandora\/object\/galston%3A1\/datastream\/JP2",
+      "width": 200,
+      "height": 200,
+      "type": "Image",
+      "format": "image\/jpeg"
+    }
+  ],
+  "items": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/0",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 1"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/0\/page\/galston:2",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/0\/page\/galston:2\/623dc4a9eab8f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:2~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:2~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/1",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 2"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/1\/page\/galston:177",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/1\/page\/galston:177\/623dc4aa57b50",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:177~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:177~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/2",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 3"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/2\/page\/galston:176",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/2\/page\/galston:176\/623dc4aab8202",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:176~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:176~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/3",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 4"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/3\/page\/galston:175",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/3\/page\/galston:175\/623dc4ab24670",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:175~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:175~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/4",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 5"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/4\/page\/galston:174",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/4\/page\/galston:174\/623dc4ab851f3",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:174~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:174~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/5",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 6"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/5\/page\/galston:173",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/5\/page\/galston:173\/623dc4abe63cc",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:173~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:173~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/5"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/6",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 7"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/6\/page\/galston:172",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/6\/page\/galston:172\/623dc4ac52757",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:172~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:172~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/7",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 8"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/7\/page\/galston:171",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/7\/page\/galston:171\/623dc4acb27a6",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:171~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:171~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/7"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/8",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 9"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/8\/page\/galston:170",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/8\/page\/galston:170\/623dc4ad1e58f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:170~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:170~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/8"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/9",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 10"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/9\/page\/galston:169",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/9\/page\/galston:169\/623dc4ad7ebca",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:169~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:169~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/10",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 11"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/10\/page\/galston:168",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/10\/page\/galston:168\/623dc4addee31",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:168~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:168~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/10"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/11",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 12"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/11\/page\/galston:167",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/11\/page\/galston:167\/623dc4ae4b001",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:167~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:167~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/11"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/12",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 13"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/12\/page\/galston:166",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/12\/page\/galston:166\/623dc4aeab390",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:166~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:166~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/12"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/13",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 14"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/13\/page\/galston:165",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/13\/page\/galston:165\/623dc4af17672",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:165~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:165~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/13"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/14",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 15"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/14\/page\/galston:164",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/14\/page\/galston:164\/623dc4af77b2b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:164~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:164~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/14"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/15",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 16"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/15\/page\/galston:163",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/15\/page\/galston:163\/623dc4afd8562",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:163~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:163~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/15"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/16",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 17"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/16\/page\/galston:162",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/16\/page\/galston:162\/623dc4b0448eb",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:162~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:162~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/16"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/17",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 18"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/17\/page\/galston:161",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/17\/page\/galston:161\/623dc4b0a4d26",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:161~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:161~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/17"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/18",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 19"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/18\/page\/galston:160",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/18\/page\/galston:160\/623dc4b1113aa",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:160~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:160~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/18"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/19",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 20"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/19\/page\/galston:159",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/19\/page\/galston:159\/623dc4b1717e4",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:159~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:159~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/19"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/20",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 21"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/20\/page\/galston:158",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/20\/page\/galston:158\/623dc4b1d182f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:158~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:158~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/20"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/21",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 22"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/21\/page\/galston:157",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/21\/page\/galston:157\/623dc4b23d6f5",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:157~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:157~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/21"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/22",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 23"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/22\/page\/galston:156",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/22\/page\/galston:156\/623dc4b29db13",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:156~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:156~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/22"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/23",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 24"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/23\/page\/galston:155",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/23\/page\/galston:155\/623dc4b30982f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:155~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:155~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/23"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/24",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 25"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/24\/page\/galston:154",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/24\/page\/galston:154\/623dc4b36a295",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:154~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:154~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/24"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/25",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 26"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/25\/page\/galston:153",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/25\/page\/galston:153\/623dc4b3ca978",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:153~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:153~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/25"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/26",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 27"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/26\/page\/galston:152",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/26\/page\/galston:152\/623dc4b436a7a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:152~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:152~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/26"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/27",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 28"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/27\/page\/galston:151",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/27\/page\/galston:151\/623dc4b4979cf",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:151~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:151~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/27"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/28",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 29"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/28\/page\/galston:150",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/28\/page\/galston:150\/623dc4b5046dc",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:150~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:150~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/28"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/29",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 30"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/29\/page\/galston:149",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/29\/page\/galston:149\/623dc4b564de4",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:149~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:149~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/29"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/30",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 31"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/30\/page\/galston:148",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/30\/page\/galston:148\/623dc4b5c58a4",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:148~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:148~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/30"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/31",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 32"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/31\/page\/galston:147",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/31\/page\/galston:147\/623dc4b631ccb",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:147~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:147~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/31"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/32",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 33"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/32\/page\/galston:146",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/32\/page\/galston:146\/623dc4b692c10",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:146~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:146~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/32"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/33",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 34"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/33\/page\/galston:145",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/33\/page\/galston:145\/623dc4b6f3309",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:145~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:145~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/33"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/34",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 35"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/34\/page\/galston:144",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/34\/page\/galston:144\/623dc4b75f2fa",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:144~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:144~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/34"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/35",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 36"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/35\/page\/galston:143",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/35\/page\/galston:143\/623dc4b7bf739",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:143~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:143~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/35"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/36",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 37"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/36\/page\/galston:142",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/36\/page\/galston:142\/623dc4b82bd08",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:142~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:142~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/36"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/37",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 38"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/37\/page\/galston:141",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/37\/page\/galston:141\/623dc4b88c233",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:141~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:141~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/37"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/38",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 39"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/38\/page\/galston:140",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/38\/page\/galston:140\/623dc4b8ec980",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:140~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:140~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/38"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/39",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 40"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/39\/page\/galston:139",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/39\/page\/galston:139\/623dc4b95914c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:139~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:139~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/39"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/40",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 41"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/40\/page\/galston:138",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/40\/page\/galston:138\/623dc4b9b9be1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:138~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:138~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/40"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/41",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 42"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/41\/page\/galston:137",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/41\/page\/galston:137\/623dc4ba25dc3",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:137~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:137~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/41"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/42",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 43"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/42\/page\/galston:136",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/42\/page\/galston:136\/623dc4ba86173",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:136~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:136~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/42"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/43",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 44"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/43\/page\/galston:135",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/43\/page\/galston:135\/623dc4bae6ab1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:135~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:135~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/43"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/44",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 45"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/44\/page\/galston:134",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/44\/page\/galston:134\/623dc4bb5306d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:134~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:134~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/44"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/45",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 46"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/45\/page\/galston:133",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/45\/page\/galston:133\/623dc4bbb3b95",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:133~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:133~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/45"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/46",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 47"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/46\/page\/galston:132",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/46\/page\/galston:132\/623dc4bc1ff1c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:132~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:132~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/46"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/47",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 48"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/47\/page\/galston:131",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/47\/page\/galston:131\/623dc4bc802d5",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:131~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:131~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/47"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/48",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 49"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/48\/page\/galston:130",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/48\/page\/galston:130\/623dc4bcdfdca",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:130~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:130~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/48"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/49",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 50"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/49\/page\/galston:129",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/49\/page\/galston:129\/623dc4bd4c64c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:129~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:129~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/49"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/50",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 51"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/50\/page\/galston:128",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/50\/page\/galston:128\/623dc4bdac9fb",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:128~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:128~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/50"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/51",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 52"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/51\/page\/galston:127",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/51\/page\/galston:127\/623dc4be192ed",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:127~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:127~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/51"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/52",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 53"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/52\/page\/galston:126",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/52\/page\/galston:126\/623dc4be79937",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:126~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:126~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/52"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/53",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 54"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/53\/page\/galston:125",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/53\/page\/galston:125\/623dc4bed981e",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:125~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:125~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/53"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/54",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 55"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/54\/page\/galston:124",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/54\/page\/galston:124\/623dc4bf456a1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:124~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:124~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/54"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/55",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 56"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/55\/page\/galston:123",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/55\/page\/galston:123\/623dc4bfa5bed",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:123~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:123~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/55"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/56",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 57"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/56\/page\/galston:122",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/56\/page\/galston:122\/623dc4c0115ca",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:122~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:122~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/56"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/57",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 58"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/57\/page\/galston:121",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/57\/page\/galston:121\/623dc4c071bfd",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:121~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:121~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/57"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/58",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 59"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/58\/page\/galston:120",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/58\/page\/galston:120\/623dc4c0d1e6f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:120~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:120~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/58"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/59",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 60"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/59\/page\/galston:119",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/59\/page\/galston:119\/623dc4c13dd06",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:119~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:119~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/59"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/60",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 61"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/60\/page\/galston:118",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/60\/page\/galston:118\/623dc4c19f4bd",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:118~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:118~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/60"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/61",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 62"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/61\/page\/galston:117",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/61\/page\/galston:117\/623dc4c20b714",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:117~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:117~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/61"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/62",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 63"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/62\/page\/galston:116",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/62\/page\/galston:116\/623dc4c26d0da",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:116~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:116~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/62"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/63",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 64"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/63\/page\/galston:115",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/63\/page\/galston:115\/623dc4c2cd2b0",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:115~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:115~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/63"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/64",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 65"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/64\/page\/galston:114",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/64\/page\/galston:114\/623dc4c3399db",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:114~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:114~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/64"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/65",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 66"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/65\/page\/galston:113",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/65\/page\/galston:113\/623dc4c3998f5",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:113~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:113~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/65"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/66",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 67"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/66\/page\/galston:112",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/66\/page\/galston:112\/623dc4c4060e5",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:112~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:112~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/66"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/67",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 68"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/67\/page\/galston:111",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/67\/page\/galston:111\/623dc4c466382",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:111~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:111~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/67"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/68",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 69"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/68\/page\/galston:110",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/68\/page\/galston:110\/623dc4c4c6812",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:110~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:110~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/68"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/69",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 70"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/69\/page\/galston:109",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/69\/page\/galston:109\/623dc4c5329c8",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:109~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:109~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/69"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/70",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 71"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/70\/page\/galston:108",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/70\/page\/galston:108\/623dc4c592a88",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:108~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:108~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/70"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/71",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 72"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/71\/page\/galston:107",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/71\/page\/galston:107\/623dc4c5f2a9f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:107~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:107~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/71"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/72",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 73"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/72\/page\/galston:106",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/72\/page\/galston:106\/623dc4c65e7d0",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:106~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:106~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/72"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/73",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 74"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/73\/page\/galston:105",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/73\/page\/galston:105\/623dc4c6bf160",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:105~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:105~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/73"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/74",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 75"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/74\/page\/galston:104",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/74\/page\/galston:104\/623dc4c72afdd",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:104~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:104~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/74"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/75",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 76"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/75\/page\/galston:103",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/75\/page\/galston:103\/623dc4c78b1da",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:103~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:103~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/75"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/76",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 77"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/76\/page\/galston:102",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/76\/page\/galston:102\/623dc4c7eb443",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:102~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:102~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/76"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/77",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 78"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/77\/page\/galston:101",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/77\/page\/galston:101\/623dc4c8572f7",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:101~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:101~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/77"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/78",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 79"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/78\/page\/galston:100",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/78\/page\/galston:100\/623dc4c8b717b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:100~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:100~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/78"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/79",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 80"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/79\/page\/galston:99",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/79\/page\/galston:99\/623dc4c923555",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:99~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:99~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/79"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/80",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 81"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/80\/page\/galston:98",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/80\/page\/galston:98\/623dc4c98465e",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:98~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:98~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/80"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/81",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 82"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/81\/page\/galston:97",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/81\/page\/galston:97\/623dc4c9e494b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:97~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:97~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/81"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/82",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 83"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/82\/page\/galston:96",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/82\/page\/galston:96\/623dc4ca51034",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:96~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:96~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/82"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/83",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 84"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/83\/page\/galston:95",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/83\/page\/galston:95\/623dc4cab1167",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:95~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:95~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/83"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/84",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 85"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/84\/page\/galston:94",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/84\/page\/galston:94\/623dc4cb1cc24",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:94~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:94~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/84"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/85",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 86"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/85\/page\/galston:93",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/85\/page\/galston:93\/623dc4cb7ce40",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:93~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:93~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/85"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/86",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 87"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/86\/page\/galston:92",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/86\/page\/galston:92\/623dc4cbdd288",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:92~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:92~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/86"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/87",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 88"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/87\/page\/galston:91",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/87\/page\/galston:91\/623dc4cc49000",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:91~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:91~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/87"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/88",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 89"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/88\/page\/galston:90",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/88\/page\/galston:90\/623dc4cca99f7",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:90~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:90~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/88"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/89",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 90"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/89\/page\/galston:89",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/89\/page\/galston:89\/623dc4cd15c9a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:89~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:89~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/89"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/90",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 91"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/90\/page\/galston:88",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/90\/page\/galston:88\/623dc4cd75a77",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:88~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:88~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/90"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/91",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 92"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/91\/page\/galston:87",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/91\/page\/galston:87\/623dc4cdd6563",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:87~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:87~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/91"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/92",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 93"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/92\/page\/galston:86",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/92\/page\/galston:86\/623dc4ce42a0f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:86~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:86~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/92"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/93",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 94"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/93\/page\/galston:85",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/93\/page\/galston:85\/623dc4cea2dee",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:85~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:85~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/93"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/94",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 95"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/94\/page\/galston:84",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/94\/page\/galston:84\/623dc4cf0f519",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:84~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:84~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/94"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/95",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 96"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/95\/page\/galston:83",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/95\/page\/galston:83\/623dc4cf6fa40",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:83~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:83~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/95"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/96",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 97"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/96\/page\/galston:82",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/96\/page\/galston:82\/623dc4cfcfc6c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:82~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:82~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/96"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/97",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 98"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/97\/page\/galston:81",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/97\/page\/galston:81\/623dc4d03c800",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:81~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:81~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/97"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/98",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 99"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/98\/page\/galston:80",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/98\/page\/galston:80\/623dc4d09cb9b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:80~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:80~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/98"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/99",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 100"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/99\/page\/galston:79",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/99\/page\/galston:79\/623dc4d109673",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:79~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:79~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/99"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/100",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 101"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/100\/page\/galston:78",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/100\/page\/galston:78\/623dc4d16a350",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:78~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:78~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/100"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/101",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 102"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/101\/page\/galston:77",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/101\/page\/galston:77\/623dc4d1cb4cf",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:77~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:77~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/101"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/102",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 103"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/102\/page\/galston:76",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/102\/page\/galston:76\/623dc4d238b31",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:76~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:76~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/102"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/103",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 104"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/103\/page\/galston:75",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/103\/page\/galston:75\/623dc4d298dcc",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:75~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:75~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/103"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/104",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 105"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/104\/page\/galston:74",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/104\/page\/galston:74\/623dc4d305176",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:74~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:74~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/104"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/105",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 106"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/105\/page\/galston:73",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/105\/page\/galston:73\/623dc4d3658b4",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:73~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:73~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/105"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/106",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 107"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/106\/page\/galston:72",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/106\/page\/galston:72\/623dc4d3c5bc9",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:72~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:72~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/106"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/107",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 108"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/107\/page\/galston:71",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/107\/page\/galston:71\/623dc4d43182c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:71~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:71~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/107"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/108",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 109"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/108\/page\/galston:70",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/108\/page\/galston:70\/623dc4d491bd0",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:70~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:70~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/108"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/109",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 110"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/109\/page\/galston:69",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/109\/page\/galston:69\/623dc4d4f1e2d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:69~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:69~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/109"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/110",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 111"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/110\/page\/galston:68",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/110\/page\/galston:68\/623dc4d55d83b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:68~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:68~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/110"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/111",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 112"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/111\/page\/galston:67",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/111\/page\/galston:67\/623dc4d5bd6d9",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:67~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:67~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/111"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/112",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 113"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/112\/page\/galston:66",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/112\/page\/galston:66\/623dc4d629b59",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:66~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:66~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/112"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/113",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 114"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/113\/page\/galston:65",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/113\/page\/galston:65\/623dc4d689b22",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:65~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:65~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/113"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/114",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 115"
+        ]
+      },
+      "width": 6197,
+      "height": 8289,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/114\/page\/galston:64",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/114\/page\/galston:64\/623dc4d6e969e",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:64~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6197,
+                  "height": 8289,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:64~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/114"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/115",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 116"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/115\/page\/galston:63",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/115\/page\/galston:63\/623dc4d755b26",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:63~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:63~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/115"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/116",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 117"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/116\/page\/galston:62",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/116\/page\/galston:62\/623dc4d7b666e",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:62~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:62~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/116"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/117",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 118"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/117\/page\/galston:61",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/117\/page\/galston:61\/623dc4d822279",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:61~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:61~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/117"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/118",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 119"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/118\/page\/galston:60",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/118\/page\/galston:60\/623dc4d8821ee",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:60~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:60~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/118"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/119",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 120"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/119\/page\/galston:59",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/119\/page\/galston:59\/623dc4d8e297f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:59~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:59~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/119"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/120",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 121"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/120\/page\/galston:58",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/120\/page\/galston:58\/623dc4d94ed3b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:58~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:58~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/120"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/121",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 122"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/121\/page\/galston:57",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/121\/page\/galston:57\/623dc4d9aefaf",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:57~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:57~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/121"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/122",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 123"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/122\/page\/galston:56",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/122\/page\/galston:56\/623dc4da1b497",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:56~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:56~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/122"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/123",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 124"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/123\/page\/galston:55",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/123\/page\/galston:55\/623dc4da7b12b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:55~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:55~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/123"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/124",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 125"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/124\/page\/galston:54",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/124\/page\/galston:54\/623dc4dadb7c1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:54~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:54~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/124"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/125",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 126"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/125\/page\/galston:53",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/125\/page\/galston:53\/623dc4db4748f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:53~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:53~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/125"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/126",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 127"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/126\/page\/galston:52",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/126\/page\/galston:52\/623dc4dba7790",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:52~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:52~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/126"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/127",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 128"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/127\/page\/galston:51",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/127\/page\/galston:51\/623dc4dc13961",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:51~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:51~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/127"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/128",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 129"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/128\/page\/galston:50",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/128\/page\/galston:50\/623dc4dc7376a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:50~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:50~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/128"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/129",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 130"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/129\/page\/galston:49",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/129\/page\/galston:49\/623dc4dcd3a3e",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:49~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:49~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/129"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/130",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 131"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/130\/page\/galston:48",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/130\/page\/galston:48\/623dc4dd3fa69",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:48~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:48~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/130"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/131",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 132"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/131\/page\/galston:47",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/131\/page\/galston:47\/623dc4dd9fafa",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:47~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:47~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/131"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/132",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 133"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/132\/page\/galston:46",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/132\/page\/galston:46\/623dc4de0be70",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:46~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:46~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/132"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/133",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 134"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/133\/page\/galston:45",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/133\/page\/galston:45\/623dc4de6c617",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:45~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:45~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/133"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/134",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 135"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/134\/page\/galston:44",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/134\/page\/galston:44\/623dc4decc4f5",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:44~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:44~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/134"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/135",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 136"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/135\/page\/galston:43",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/135\/page\/galston:43\/623dc4df38ad7",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:43~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:43~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/135"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/136",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 137"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/136\/page\/galston:42",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/136\/page\/galston:42\/623dc4df999b6",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:42~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:42~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/136"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/137",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 138"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/137\/page\/galston:41",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/137\/page\/galston:41\/623dc4e005cf6",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:41~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:41~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/137"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/138",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 139"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/138\/page\/galston:40",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/138\/page\/galston:40\/623dc4e066064",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:40~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:40~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/138"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/139",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 140"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/139\/page\/galston:39",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/139\/page\/galston:39\/623dc4e0c5c5a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:39~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:39~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/139"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/140",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 141"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/140\/page\/galston:38",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/140\/page\/galston:38\/623dc4e131c54",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:38~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:38~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/140"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/141",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 142"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/141\/page\/galston:37",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/141\/page\/galston:37\/623dc4e1916e3",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:37~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:37~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/141"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/142",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 143"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/142\/page\/galston:36",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/142\/page\/galston:36\/623dc4e1f1a3a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:36~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:36~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/142"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/143",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 144"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/143\/page\/galston:35",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/143\/page\/galston:35\/623dc4e25db64",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:35~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:35~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/143"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/144",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 145"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/144\/page\/galston:34",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/144\/page\/galston:34\/623dc4e2bda61",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:34~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:34~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/144"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/145",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 146"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/145\/page\/galston:33",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/145\/page\/galston:33\/623dc4e329818",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:33~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:33~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/145"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/146",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 147"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/146\/page\/galston:32",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/146\/page\/galston:32\/623dc4e3892a8",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:32~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:32~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/146"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/147",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 148"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/147\/page\/galston:31",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/147\/page\/galston:31\/623dc4e3e91c7",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:31~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:31~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/147"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/148",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 149"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/148\/page\/galston:30",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/148\/page\/galston:30\/623dc4e4551f7",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:30~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:30~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/148"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/149",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 150"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/149\/page\/galston:29",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/149\/page\/galston:29\/623dc4e4b4f11",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:29~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:29~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/149"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/150",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 151"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/150\/page\/galston:28",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/150\/page\/galston:28\/623dc4e521399",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:28~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:28~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/150"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/151",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 152"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/151\/page\/galston:27",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/151\/page\/galston:27\/623dc4e58151d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:27~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:27~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/151"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/152",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 153"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/152\/page\/galston:26",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/152\/page\/galston:26\/623dc4e5e1535",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:26~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:26~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/152"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/153",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 154"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/153\/page\/galston:25",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/153\/page\/galston:25\/623dc4e64d4d8",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:25~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:25~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/153"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/154",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 155"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/154\/page\/galston:24",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/154\/page\/galston:24\/623dc4e6ad805",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:24~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:24~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/154"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/155",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 156"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/155\/page\/galston:23",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/155\/page\/galston:23\/623dc4e71998b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:23~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:23~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/155"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/156",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 157"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/156\/page\/galston:22",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/156\/page\/galston:22\/623dc4e779818",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:22~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:22~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/156"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/157",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 158"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/157\/page\/galston:21",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/157\/page\/galston:21\/623dc4e7d9c3c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:21~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:21~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/157"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/158",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 159"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/158\/page\/galston:20",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/158\/page\/galston:20\/623dc4e845477",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:20~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:20~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/158"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/159",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 160"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/159\/page\/galston:19",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/159\/page\/galston:19\/623dc4e8a5c18",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:19~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:19~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/159"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/160",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 161"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/160\/page\/galston:18",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/160\/page\/galston:18\/623dc4e911911",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:18~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:18~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/160"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/161",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 162"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/161\/page\/galston:17",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/161\/page\/galston:17\/623dc4e9713e1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:17~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:17~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/161"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/162",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 163"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/162\/page\/galston:16",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/162\/page\/galston:16\/623dc4e9d1cab",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:16~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:16~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/162"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/163",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 164"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/163\/page\/galston:15",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/163\/page\/galston:15\/623dc4ea3e003",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:15~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:15~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/163"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/164",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 165"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/164\/page\/galston:14",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/164\/page\/galston:14\/623dc4ea9db5d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:14~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:14~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/164"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/165",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 166"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/165\/page\/galston:13",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/165\/page\/galston:13\/623dc4eb09f4a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:13~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:13~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/165"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/166",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 167"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/166\/page\/galston:12",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/166\/page\/galston:12\/623dc4eb6a239",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:12~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:12~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/166"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/167",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 168"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/167\/page\/galston:11",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/167\/page\/galston:11\/623dc4ebc9f5d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:11~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:11~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/167"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/168",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 169"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/168\/page\/galston:10",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/168\/page\/galston:10\/623dc4ec3629c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:10~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:10~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/168"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/169",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 170"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/169\/page\/galston:9",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/169\/page\/galston:9\/623dc4ec96194",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:9~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:9~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/169"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/170",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 171"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/170\/page\/galston:8",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/170\/page\/galston:8\/623dc4ed027d9",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:8~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:8~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/170"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/171",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 172"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/171\/page\/galston:7",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/171\/page\/galston:7\/623dc4ed62e26",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:7~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:7~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/171"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/172",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 173"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/172\/page\/galston:6",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/172\/page\/galston:6\/623dc4edc2d0c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:6~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:6~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/172"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/173",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 174"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/173\/page\/galston:5",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/173\/page\/galston:5\/623dc4ee2f1a7",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:5~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:5~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/173"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/174",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 175"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/174\/page\/galston:4",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/174\/page\/galston:4\/623dc4ee8fc43",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:4~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:4~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/174"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/175",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 176"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/175\/page\/galston:3",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/175\/page\/galston:3\/623dc4eef03f3",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:3~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:3~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/175"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/176",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Programme zum Zyklus von vierzig Konzerten:  page 177"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/176\/page\/galston:714",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/176\/page\/galston:714\/623dc4ef5c0b8",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:714~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:714~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1\/canvas\/176"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "seeAlso": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/collections\/islandora\/object\/galston%3A1\/datastream\/MODS",
+      "type": "Dataset",
+      "label": {
+        "en": [
+          "Bibliographic Description in MODS"
+        ]
+      },
+      "format": "application\/xml",
+      "profile": "http:\/\/www.loc.gov\/standards\/mods\/v3\/mods-3-5.xsd"
+    }
+  ],
+  "behavior": [
+    "paged"
+  ]
+}

--- a/iiif/galston_1.json
+++ b/iiif/galston_1.json
@@ -2,7 +2,7 @@
   "@context": [
     "https:\/\/iiif.io\/api\/presentation\/3\/context.json"
   ],
-  "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/1",
+  "id": "https:\/\/digital.lib.utk.edu\/static\/iiif\/galston_1.json",
   "type": "Manifest",
   "label": {
     "en": [

--- a/iiif/galston_178.json
+++ b/iiif/galston_178.json
@@ -1,0 +1,19675 @@
+{
+  "@context": [
+    "https:\/\/iiif.io\/api\/presentation\/3\/context.json"
+  ],
+  "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178",
+  "type": "Manifest",
+  "label": {
+    "en": [
+      "Studienbuch"
+    ]
+  },
+  "summary": {
+    "en": [
+      "Detailed commentary on the performance of selected piano works by Bach, Beethoven, Chopin, Liszt and Brahms. This copy includes handwritten notes charting out various concerts that Galston performed as part of his cycle of 40 historical recitals in Germany between 1919 and 1921."
+    ]
+  },
+  "metadata": [
+    {
+      "label": {
+        "en": [
+          "Table of Contents"
+        ]
+      },
+      "value": {
+        "en": [
+          "Vorwort -- Bach -- Beethoven -- Chopin -- Liszt -- Brahms -- Anhang -- Register"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Publisher"
+        ]
+      },
+      "value": {
+        "en": [
+          "Verlag Bruno Cassirer"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Publication Date"
+        ]
+      },
+      "value": {
+        "en": [
+          "1910",
+          "1910"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Format"
+        ]
+      },
+      "value": {
+        "en": [
+          "books"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Extent"
+        ]
+      },
+      "value": {
+        "en": [
+          "26 cm high",
+          "498 pages, spine of book"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Subject"
+        ]
+      },
+      "value": {
+        "en": [
+          "Music",
+          "Piano music"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Description"
+        ]
+      },
+      "value": {
+        "en": [
+          "Detailed commentary on the performance of selected piano works by Bach, Beethoven, Chopin, Liszt and Brahms. This copy includes handwritten notes charting out various concerts that Galston performed as part of his cycle of 40 historical recitals in Germany between 1919 and 1921."
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Language"
+        ]
+      },
+      "value": {
+        "en": [
+          "German"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Author"
+        ]
+      },
+      "value": {
+        "en": [
+          "Galston, Gottfried, 1879-1950"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Binding designer"
+        ]
+      },
+      "value": {
+        "en": [
+          "Ebert, K."
+        ]
+      }
+    }
+  ],
+  "rights": "http:\/\/rightsstatements.org\/vocab\/NKC\/1.0\/",
+  "requiredStatement": {
+    "label": {
+      "en": [
+        "Provided by"
+      ]
+    },
+    "value": {
+      "en": [
+        "University of Tennessee, Knoxville. Libraries"
+      ]
+    }
+  },
+  "provider": [
+    {
+      "id": "https:\/\/www.lib.utk.edu\/about\/",
+      "type": "Agent",
+      "label": {
+        "en": [
+          "University of Tennessee, Knoxville. Libraries"
+        ]
+      },
+      "homepage": [
+        {
+          "id": "https:\/\/www.lib.utk.edu\/",
+          "type": "Text",
+          "label": {
+            "en": [
+              "University of Tennessee Libraries Homepage"
+            ]
+          },
+          "format": "text\/html"
+        }
+      ],
+      "logo": [
+        {
+          "id": "https:\/\/utkdigitalinitiatives.github.io\/iiif-level-0\/ut_libraries_centered\/full\/full\/0\/default.jpg",
+          "type": "Image",
+          "format": "image\/jpeg",
+          "width": 200,
+          "height": 200
+        }
+      ]
+    }
+  ],
+  "thumbnail": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/collections\/islandora\/object\/galston%3A178\/datastream\/JP2",
+      "width": 200,
+      "height": 200,
+      "type": "Image",
+      "format": "image\/jpeg"
+    }
+  ],
+  "items": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/0",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 1"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/0\/page\/galston:219",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/0\/page\/galston:219\/623dc4f0c011f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:219~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:219~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/1",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 2"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/1\/page\/galston:181",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/1\/page\/galston:181\/623dc4f12bdf7",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:181~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:181~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/2",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 3"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/2\/page\/galston:448",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/2\/page\/galston:448\/623dc4f18be23",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:448~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:448~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/3",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 4"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/3\/page\/galston:190",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/3\/page\/galston:190\/623dc4f1ec918",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:190~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:190~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/4",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 5"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/4\/page\/galston:447",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/4\/page\/galston:447\/623dc4f2588f3",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:447~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:447~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/5",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 6"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/5\/page\/galston:227",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/5\/page\/galston:227\/623dc4f2b889d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:227~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:227~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/5"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/6",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 7"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/6\/page\/galston:446",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/6\/page\/galston:446\/623dc4f3245f4",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:446~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:446~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/7",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 8"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/7\/page\/galston:189",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/7\/page\/galston:189\/623dc4f3844a2",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:189~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:189~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/7"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/8",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 9"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/8\/page\/galston:445",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/8\/page\/galston:445\/623dc4f3e4046",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:445~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:445~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/8"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/9",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 10"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/9\/page\/galston:226",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/9\/page\/galston:226\/623dc4f4501ce",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:226~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:226~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/10",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 11"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/10\/page\/galston:444",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/10\/page\/galston:444\/623dc4f4affbf",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:444~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:444~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/10"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/11",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 12"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/11\/page\/galston:188",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/11\/page\/galston:188\/623dc4f51bdad",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:188~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:188~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/11"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/12",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 13"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/12\/page\/galston:443",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/12\/page\/galston:443\/623dc4f57bbde",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:443~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:443~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/12"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/13",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 14"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/13\/page\/galston:225",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/13\/page\/galston:225\/623dc4f5dbfd9",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:225~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:225~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/13"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/14",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 15"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/14\/page\/galston:442",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/14\/page\/galston:442\/623dc4f648f0c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:442~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:442~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/14"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/15",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 16"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/15\/page\/galston:187",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/15\/page\/galston:187\/623dc4f6a9a98",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:187~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:187~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/15"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/16",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 17"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/16\/page\/galston:441",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/16\/page\/galston:441\/623dc4f7156d4",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:441~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:441~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/16"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/17",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 18"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/17\/page\/galston:224",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/17\/page\/galston:224\/623dc4f775508",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:224~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:224~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/17"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/18",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 19"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/18\/page\/galston:440",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/18\/page\/galston:440\/623dc4f7d5502",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:440~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:440~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/18"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/19",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 20"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/19\/page\/galston:186",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/19\/page\/galston:186\/623dc4f841332",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:186~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:186~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/19"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/20",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 21"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/20\/page\/galston:439",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/20\/page\/galston:439\/623dc4f8a117b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:439~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:439~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/20"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/21",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 22"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/21\/page\/galston:223",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/21\/page\/galston:223\/623dc4f90c9f1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:223~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:223~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/21"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/22",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 23"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/22\/page\/galston:438",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/22\/page\/galston:438\/623dc4f96c526",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:438~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:438~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/22"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/23",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 24"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/23\/page\/galston:185",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/23\/page\/galston:185\/623dc4f9cc161",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:185~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:185~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/23"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/24",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 25"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/24\/page\/galston:437",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/24\/page\/galston:437\/623dc4fa38317",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:437~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:437~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/24"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/25",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 26"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/25\/page\/galston:222",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/25\/page\/galston:222\/623dc4fa984c1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:222~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:222~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/25"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/26",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 27"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/26\/page\/galston:436",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/26\/page\/galston:436\/623dc4fb03dec",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:436~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:436~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/26"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/27",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 28"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/27\/page\/galston:184",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/27\/page\/galston:184\/623dc4fb638b5",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:184~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:184~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/27"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/28",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 29"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/28\/page\/galston:435",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/28\/page\/galston:435\/623dc4fbc34b5",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:435~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:435~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/28"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/29",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 30"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/29\/page\/galston:221",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/29\/page\/galston:221\/623dc4fc2f27e",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:221~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:221~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/29"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/30",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 31"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/30\/page\/galston:179",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/30\/page\/galston:179\/623dc4fc8f33c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:179~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:179~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/30"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/31",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 32"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/31\/page\/galston:183",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/31\/page\/galston:183\/623dc4fcef41b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:183~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:183~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/31"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/32",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 33"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/32\/page\/galston:676",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/32\/page\/galston:676\/623dc4fd5abf5",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:676~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:676~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/32"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/33",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 34"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/33\/page\/galston:434",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/33\/page\/galston:434\/623dc4fdba809",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:434~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:434~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/33"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/34",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 35"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/34\/page\/galston:675",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/34\/page\/galston:675\/623dc4fe264eb",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:675~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:675~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/34"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/35",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 36"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/35\/page\/galston:433",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/35\/page\/galston:433\/623dc4fe85f72",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:433~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:433~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/35"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/36",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 37"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/36\/page\/galston:674",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/36\/page\/galston:674\/623dc4fee6254",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:674~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:674~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/36"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/37",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 38"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/37\/page\/galston:432",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/37\/page\/galston:432\/623dc4ff51f54",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:432~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:432~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/37"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/38",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 39"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/38\/page\/galston:673",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/38\/page\/galston:673\/623dc4ffb1bdc",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:673~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:673~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/38"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/39",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 40"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/39\/page\/galston:431",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/39\/page\/galston:431\/623dc5001dfaf",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:431~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:431~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/39"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/40",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 41"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/40\/page\/galston:672",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/40\/page\/galston:672\/623dc5007dfc4",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:672~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:672~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/40"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/41",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 42"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/41\/page\/galston:430",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/41\/page\/galston:430\/623dc500dde8c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:430~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:430~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/41"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/42",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 43"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/42\/page\/galston:671",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/42\/page\/galston:671\/623dc5014a33c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:671~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:671~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/42"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/43",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 44"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/43\/page\/galston:429",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/43\/page\/galston:429\/623dc501aa7e7",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:429~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:429~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/43"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/44",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 45"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/44\/page\/galston:670",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/44\/page\/galston:670\/623dc502162f0",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:670~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:670~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/44"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/45",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 46"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/45\/page\/galston:428",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/45\/page\/galston:428\/623dc5027617c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:428~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:428~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/45"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/46",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 47"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/46\/page\/galston:669",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/46\/page\/galston:669\/623dc502d61f1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:669~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:669~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/46"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/47",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 48"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/47\/page\/galston:427",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/47\/page\/galston:427\/623dc503424c7",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:427~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:427~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/47"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/48",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 49"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/48\/page\/galston:668",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/48\/page\/galston:668\/623dc503a2519",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:668~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:668~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/48"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/49",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 50"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/49\/page\/galston:426",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/49\/page\/galston:426\/623dc5040ea5a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:426~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:426~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/49"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/50",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 51"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/50\/page\/galston:667",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/50\/page\/galston:667\/623dc5046e80d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:667~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:667~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/50"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/51",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 52"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/51\/page\/galston:425",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/51\/page\/galston:425\/623dc504ce346",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:425~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:425~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/51"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/52",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 53"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/52\/page\/galston:666",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/52\/page\/galston:666\/623dc5053a1fd",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:666~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:666~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/52"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/53",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 54"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/53\/page\/galston:424",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/53\/page\/galston:424\/623dc50599bcd",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:424~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:424~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/53"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/54",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 55"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/54\/page\/galston:665",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/54\/page\/galston:665\/623dc506054c4",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:665~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:665~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/54"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/55",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 56"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/55\/page\/galston:423",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/55\/page\/galston:423\/623dc50665c28",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:423~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:423~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/55"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/56",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 57"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/56\/page\/galston:664",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/56\/page\/galston:664\/623dc506c5829",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:664~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:664~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/56"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/57",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 58"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/57\/page\/galston:422",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/57\/page\/galston:422\/623dc507313a6",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:422~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:422~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/57"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/58",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 59"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/58\/page\/galston:663",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/58\/page\/galston:663\/623dc507917d7",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:663~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:663~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/58"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/59",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 60"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/59\/page\/galston:218",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/59\/page\/galston:218\/623dc507f11ea",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:218~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:218~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/59"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/60",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 61"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/60\/page\/galston:662",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/60\/page\/galston:662\/623dc5085cc35",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:662~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:662~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/60"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/61",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 62"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/61\/page\/galston:421",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/61\/page\/galston:421\/623dc508bcf20",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:421~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:421~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/61"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/62",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 63"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/62\/page\/galston:661",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/62\/page\/galston:661\/623dc509293a0",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:661~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:661~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/62"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/63",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 64"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/63\/page\/galston:420",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/63\/page\/galston:420\/623dc5098928d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:420~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:420~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/63"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/64",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 65"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/64\/page\/galston:660",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/64\/page\/galston:660\/623dc509e91da",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:660~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:660~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/64"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/65",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 66"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/65\/page\/galston:419",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/65\/page\/galston:419\/623dc50a54a41",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:419~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:419~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/65"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/66",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 67"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/66\/page\/galston:659",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/66\/page\/galston:659\/623dc50ab4688",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:659~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:659~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/66"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/67",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 68"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/67\/page\/galston:418",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/67\/page\/galston:418\/623dc50b203bb",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:418~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:418~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/67"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/68",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 69"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/68\/page\/galston:658",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/68\/page\/galston:658\/623dc50b7fd2b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:658~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:658~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/68"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/69",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 70"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/69\/page\/galston:417",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/69\/page\/galston:417\/623dc50bdf941",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:417~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:417~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/69"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/70",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 71"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/70\/page\/galston:657",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/70\/page\/galston:657\/623dc50c4b725",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:657~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:657~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/70"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/71",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 72"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/71\/page\/galston:416",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/71\/page\/galston:416\/623dc50cab972",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:416~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:416~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/71"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/72",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 73"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/72\/page\/galston:656",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/72\/page\/galston:656\/623dc50d1765d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:656~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:656~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/72"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/73",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 74"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/73\/page\/galston:415",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/73\/page\/galston:415\/623dc50d775c3",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:415~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:415~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/73"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/74",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 75"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/74\/page\/galston:655",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/74\/page\/galston:655\/623dc50dd7053",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:655~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:655~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/74"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/75",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 76"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/75\/page\/galston:414",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/75\/page\/galston:414\/623dc50e42a49",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:414~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:414~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/75"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/76",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 77"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/76\/page\/galston:654",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/76\/page\/galston:654\/623dc50ea2cf9",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:654~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:654~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/76"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/77",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 78"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/77\/page\/galston:413",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/77\/page\/galston:413\/623dc50f0e4af",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:413~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:413~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/77"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/78",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 79"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/78\/page\/galston:653",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/78\/page\/galston:653\/623dc50f6e5ae",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:653~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:653~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/78"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/79",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 80"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/79\/page\/galston:412",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/79\/page\/galston:412\/623dc50fce499",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:412~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:412~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/79"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/80",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 81"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/80\/page\/galston:652",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/80\/page\/galston:652\/623dc5103a27b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:652~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:652~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/80"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/81",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 82"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/81\/page\/galston:411",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/81\/page\/galston:411\/623dc5109a4b0",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:411~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:411~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/81"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/82",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 83"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/82\/page\/galston:651",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/82\/page\/galston:651\/623dc5110664b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:651~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:651~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/82"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/83",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 84"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/83\/page\/galston:410",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/83\/page\/galston:410\/623dc511663ff",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:410~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:410~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/83"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/84",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 85"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/84\/page\/galston:650",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/84\/page\/galston:650\/623dc511c5f30",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:650~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:650~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/84"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/85",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 86"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/85\/page\/galston:409",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/85\/page\/galston:409\/623dc51232862",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:409~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:409~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/85"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/86",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 87"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/86\/page\/galston:649",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/86\/page\/galston:649\/623dc512921db",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:649~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:649~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/86"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/87",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 88"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/87\/page\/galston:408",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/87\/page\/galston:408\/623dc512f1e96",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:408~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:408~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/87"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/88",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 89"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/88\/page\/galston:648",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/88\/page\/galston:648\/623dc5135e36d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:648~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:648~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/88"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/89",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 90"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/89\/page\/galston:407",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/89\/page\/galston:407\/623dc513be66f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:407~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:407~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/89"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/90",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 91"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/90\/page\/galston:647",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/90\/page\/galston:647\/623dc51429f25",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:647~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:647~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/90"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/91",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 92"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/91\/page\/galston:406",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/91\/page\/galston:406\/623dc5148a322",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:406~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:406~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/91"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/92",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 93"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/92\/page\/galston:646",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/92\/page\/galston:646\/623dc514ea977",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:646~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:646~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/92"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/93",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 94"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/93\/page\/galston:405",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/93\/page\/galston:405\/623dc515561cb",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:405~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:405~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/93"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/94",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 95"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/94\/page\/galston:645",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/94\/page\/galston:645\/623dc515b624f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:645~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:645~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/94"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/95",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 96"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/95\/page\/galston:404",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/95\/page\/galston:404\/623dc51621dd0",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:404~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:404~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/95"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/96",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 97"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/96\/page\/galston:644",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/96\/page\/galston:644\/623dc51681d8a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:644~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:644~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/96"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/97",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 98"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/97\/page\/galston:403",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/97\/page\/galston:403\/623dc516e1d07",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:403~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:403~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/97"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/98",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 99"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/98\/page\/galston:643",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/98\/page\/galston:643\/623dc5174d552",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:643~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:643~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/98"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/99",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 100"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/99\/page\/galston:402",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/99\/page\/galston:402\/623dc517ad058",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:402~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:402~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/99"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/100",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 101"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/100\/page\/galston:642",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/100\/page\/galston:642\/623dc51818d80",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:642~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:642~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/100"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/101",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 102"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/101\/page\/galston:401",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/101\/page\/galston:401\/623dc51878967",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:401~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:401~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/101"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/102",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 103"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/102\/page\/galston:641",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/102\/page\/galston:641\/623dc518d8482",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:641~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:641~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/102"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/103",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 104"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/103\/page\/galston:400",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/103\/page\/galston:400\/623dc519441a3",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:400~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:400~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/103"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/104",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 105"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/104\/page\/galston:640",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/104\/page\/galston:640\/623dc519a4984",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:640~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:640~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/104"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/105",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 106"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/105\/page\/galston:399",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/105\/page\/galston:399\/623dc51a10d7d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:399~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:399~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/105"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/106",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 107"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/106\/page\/galston:639",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/106\/page\/galston:639\/623dc51a712bb",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:639~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:639~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/106"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/107",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 108"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/107\/page\/galston:398",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/107\/page\/galston:398\/623dc51ad0e35",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:398~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:398~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/107"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/108",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 109"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/108\/page\/galston:638",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/108\/page\/galston:638\/623dc51b3cb93",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:638~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:638~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/108"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/109",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 110"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/109\/page\/galston:397",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/109\/page\/galston:397\/623dc51b9cbb8",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:397~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:397~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/109"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/110",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 111"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/110\/page\/galston:637",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/110\/page\/galston:637\/623dc51c0876b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:637~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:637~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/110"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/111",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 112"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/111\/page\/galston:396",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/111\/page\/galston:396\/623dc51c686c9",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:396~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:396~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/111"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/112",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 113"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/112\/page\/galston:636",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/112\/page\/galston:636\/623dc51cc879a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:636~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:636~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/112"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/113",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 114"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/113\/page\/galston:395",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/113\/page\/galston:395\/623dc51d34332",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:395~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:395~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/113"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/114",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 115"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/114\/page\/galston:635",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/114\/page\/galston:635\/623dc51d9469f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:635~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:635~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/114"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/115",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 116"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/115\/page\/galston:394",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/115\/page\/galston:394\/623dc51e007aa",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:394~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:394~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/115"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/116",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 117"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/116\/page\/galston:634",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/116\/page\/galston:634\/623dc51e605c6",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:634~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:634~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/116"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/117",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 118"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/117\/page\/galston:393",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/117\/page\/galston:393\/623dc51ec0915",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:393~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:393~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/117"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/118",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 119"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/118\/page\/galston:633",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/118\/page\/galston:633\/623dc51f2c735",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:633~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:633~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/118"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/119",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 120"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/119\/page\/galston:392",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/119\/page\/galston:392\/623dc51f8c162",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:392~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:392~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/119"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/120",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 121"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/120\/page\/galston:632",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/120\/page\/galston:632\/623dc51febdf2",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:632~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:632~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/120"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/121",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 122"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/121\/page\/galston:391",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/121\/page\/galston:391\/623dc52057e27",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:391~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:391~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/121"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/122",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 123"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/122\/page\/galston:631",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/122\/page\/galston:631\/623dc520b7c63",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:631~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:631~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/122"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/123",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 124"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/123\/page\/galston:390",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/123\/page\/galston:390\/623dc5212363c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:390~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:390~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/123"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/124",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 125"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/124\/page\/galston:630",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/124\/page\/galston:630\/623dc52183574",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:630~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:630~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/124"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/125",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 126"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/125\/page\/galston:389",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/125\/page\/galston:389\/623dc521e3464",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:389~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:389~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/125"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/126",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 127"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/126\/page\/galston:629",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/126\/page\/galston:629\/623dc5224f1e9",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:629~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:629~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/126"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/127",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 128"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/127\/page\/galston:388",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/127\/page\/galston:388\/623dc522aec55",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:388~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:388~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/127"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/128",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 129"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/128\/page\/galston:628",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/128\/page\/galston:628\/623dc5231a63c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:628~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:628~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/128"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/129",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 130"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/129\/page\/galston:387",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/129\/page\/galston:387\/623dc5237a3ae",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:387~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:387~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/129"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/130",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 131"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/130\/page\/galston:627",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/130\/page\/galston:627\/623dc523da856",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:627~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:627~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/130"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/131",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 132"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/131\/page\/galston:386",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/131\/page\/galston:386\/623dc52446845",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:386~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:386~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/131"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/132",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 133"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/132\/page\/galston:626",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/132\/page\/galston:626\/623dc524a67bb",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:626~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:626~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/132"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/133",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 134"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/133\/page\/galston:385",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/133\/page\/galston:385\/623dc52512451",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:385~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:385~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/133"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/134",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 135"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/134\/page\/galston:625",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/134\/page\/galston:625\/623dc52572314",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:625~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:625~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/134"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/135",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 136"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/135\/page\/galston:384",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/135\/page\/galston:384\/623dc525d1f54",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:384~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:384~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/135"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/136",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 137"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/136\/page\/galston:624",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/136\/page\/galston:624\/623dc526404b4",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:624~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:624~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/136"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/137",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 138"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/137\/page\/galston:383",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/137\/page\/galston:383\/623dc526a0edd",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:383~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:383~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/137"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/138",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 139"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/138\/page\/galston:623",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/138\/page\/galston:623\/623dc5270e6de",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:623~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:623~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/138"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/139",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 140"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/139\/page\/galston:382",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/139\/page\/galston:382\/623dc5276ed4d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:382~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:382~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/139"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/140",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 141"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/140\/page\/galston:622",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/140\/page\/galston:622\/623dc527cec99",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:622~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:622~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/140"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/141",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 142"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/141\/page\/galston:381",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/141\/page\/galston:381\/623dc5283ada2",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:381~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:381~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/141"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/142",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 143"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/142\/page\/galston:621",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/142\/page\/galston:621\/623dc5289b053",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:621~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:621~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/142"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/143",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 144"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/143\/page\/galston:380",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/143\/page\/galston:380\/623dc52906a9f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:380~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:380~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/143"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/144",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 145"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/144\/page\/galston:620",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/144\/page\/galston:620\/623dc529667c2",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:620~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:620~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/144"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/145",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 146"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/145\/page\/galston:379",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/145\/page\/galston:379\/623dc529c62fb",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:379~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:379~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/145"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/146",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 147"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/146\/page\/galston:619",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/146\/page\/galston:619\/623dc52a31cfc",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:619~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:619~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/146"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/147",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 148"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/147\/page\/galston:378",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/147\/page\/galston:378\/623dc52a91b8f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:378~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:378~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/147"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/148",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 149"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/148\/page\/galston:618",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/148\/page\/galston:618\/623dc52af1ae9",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:618~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:618~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/148"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/149",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 150"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/149\/page\/galston:377",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/149\/page\/galston:377\/623dc52b5d6c3",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:377~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:377~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/149"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/150",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 151"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/150\/page\/galston:617",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/150\/page\/galston:617\/623dc52bbd2c9",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:617~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:617~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/150"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/151",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 152"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/151\/page\/galston:376",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/151\/page\/galston:376\/623dc52c290a4",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:376~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:376~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/151"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/152",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 153"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/152\/page\/galston:616",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/152\/page\/galston:616\/623dc52c88ede",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:616~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:616~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/152"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/153",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 154"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/153\/page\/galston:375",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/153\/page\/galston:375\/623dc52ce8aa7",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:375~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:375~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/153"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/154",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 155"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/154\/page\/galston:615",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/154\/page\/galston:615\/623dc52d54734",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:615~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:615~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/154"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/155",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 156"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/155\/page\/galston:374",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/155\/page\/galston:374\/623dc52db46a5",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:374~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:374~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/155"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/156",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 157"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/156\/page\/galston:614",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/156\/page\/galston:614\/623dc52e1ff22",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:614~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:614~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/156"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/157",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 158"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/157\/page\/galston:373",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/157\/page\/galston:373\/623dc52e8029f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:373~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:373~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/157"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/158",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 159"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/158\/page\/galston:613",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/158\/page\/galston:613\/623dc52edfccb",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:613~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:613~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/158"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/159",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 160"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/159\/page\/galston:372",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/159\/page\/galston:372\/623dc52f4b5ca",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:372~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:372~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/159"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/160",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 161"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/160\/page\/galston:612",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/160\/page\/galston:612\/623dc52fab55a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:612~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:612~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/160"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/161",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 162"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/161\/page\/galston:371",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/161\/page\/galston:371\/623dc53016ea6",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:371~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:371~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/161"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/162",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 163"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/162\/page\/galston:611",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/162\/page\/galston:611\/623dc5307707c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:611~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:611~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/162"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/163",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 164"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/163\/page\/galston:370",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/163\/page\/galston:370\/623dc530d6d29",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:370~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:370~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/163"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/164",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 165"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/164\/page\/galston:610",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/164\/page\/galston:610\/623dc531425fc",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:610~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:610~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/164"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/165",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 166"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/165\/page\/galston:369",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/165\/page\/galston:369\/623dc531a25bb",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:369~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:369~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/165"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/166",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 167"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/166\/page\/galston:609",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/166\/page\/galston:609\/623dc5320eb02",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:609~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:609~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/166"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/167",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 168"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/167\/page\/galston:368",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/167\/page\/galston:368\/623dc5326e87c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:368~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:368~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/167"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/168",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 169"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/168\/page\/galston:608",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/168\/page\/galston:608\/623dc532ce753",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:608~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:608~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/168"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/169",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 170"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/169\/page\/galston:367",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/169\/page\/galston:367\/623dc5333a5ad",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:367~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:367~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/169"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/170",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 171"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/170\/page\/galston:607",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/170\/page\/galston:607\/623dc5339a368",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:607~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:607~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/170"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/171",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 172"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/171\/page\/galston:366",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/171\/page\/galston:366\/623dc53406046",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:366~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:366~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/171"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/172",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 173"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/172\/page\/galston:606",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/172\/page\/galston:606\/623dc534660a1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:606~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:606~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/172"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/173",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 174"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/173\/page\/galston:365",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/173\/page\/galston:365\/623dc534c5ece",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:365~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:365~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/173"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/174",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 175"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/174\/page\/galston:605",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/174\/page\/galston:605\/623dc53531c2e",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:605~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:605~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/174"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/175",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 176"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/175\/page\/galston:364",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/175\/page\/galston:364\/623dc53591b0e",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:364~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:364~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/175"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/176",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 177"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/176\/page\/galston:604",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/176\/page\/galston:604\/623dc535f1663",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:604~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:604~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/176"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/177",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 178"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/177\/page\/galston:363",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/177\/page\/galston:363\/623dc5365d3fb",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:363~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:363~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/177"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/178",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 179"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/178\/page\/galston:603",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/178\/page\/galston:603\/623dc536bd73f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:603~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:603~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/178"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/179",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 180"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/179\/page\/galston:362",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/179\/page\/galston:362\/623dc53729748",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:362~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:362~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/179"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/180",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 181"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/180\/page\/galston:602",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/180\/page\/galston:602\/623dc53789355",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:602~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:602~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/180"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/181",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 182"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/181\/page\/galston:361",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/181\/page\/galston:361\/623dc537e99ec",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:361~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:361~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/181"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/182",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 183"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/182\/page\/galston:601",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/182\/page\/galston:601\/623dc538559fa",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:601~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:601~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/182"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/183",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 184"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/183\/page\/galston:360",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/183\/page\/galston:360\/623dc538b5519",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:360~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:360~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/183"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/184",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 185"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/184\/page\/galston:600",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/184\/page\/galston:600\/623dc53920ead",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:600~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:600~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/184"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/185",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 186"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/185\/page\/galston:359",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/185\/page\/galston:359\/623dc539811fb",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:359~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:359~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/185"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/186",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 187"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/186\/page\/galston:599",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/186\/page\/galston:599\/623dc539e1105",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:599~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:599~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/186"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/187",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 188"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/187\/page\/galston:358",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/187\/page\/galston:358\/623dc53a4cddb",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:358~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:358~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/187"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/188",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 189"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/188\/page\/galston:598",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/188\/page\/galston:598\/623dc53aac919",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:598~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:598~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/188"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/189",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 190"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/189\/page\/galston:357",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/189\/page\/galston:357\/623dc53b18569",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:357~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:357~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/189"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/190",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 191"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/190\/page\/galston:597",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/190\/page\/galston:597\/623dc53b7852e",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:597~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:597~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/190"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/191",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 192"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/191\/page\/galston:356",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/191\/page\/galston:356\/623dc53bd7ffe",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:356~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:356~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/191"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/192",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 193"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/192\/page\/galston:596",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/192\/page\/galston:596\/623dc53c4392c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:596~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:596~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/192"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/193",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 194"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/193\/page\/galston:355",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/193\/page\/galston:355\/623dc53ca394e",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:355~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:355~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/193"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/194",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 195"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/194\/page\/galston:595",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/194\/page\/galston:595\/623dc53d0f575",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:595~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:595~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/194"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/195",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 196"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/195\/page\/galston:354",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/195\/page\/galston:354\/623dc53d6f011",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:354~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:354~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/195"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/196",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 197"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/196\/page\/galston:594",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/196\/page\/galston:594\/623dc53dcf073",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:594~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:594~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/196"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/197",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 198"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/197\/page\/galston:353",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/197\/page\/galston:353\/623dc53e3ac14",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:353~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:353~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/197"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/198",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 199"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/198\/page\/galston:593",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/198\/page\/galston:593\/623dc53e9a88d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:593~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:593~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/198"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/199",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 200"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/199\/page\/galston:352",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/199\/page\/galston:352\/623dc53f06986",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:352~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:352~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/199"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/200",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 201"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/200\/page\/galston:592",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/200\/page\/galston:592\/623dc53f66531",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:592~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:592~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/200"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/201",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 202"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/201\/page\/galston:351",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/201\/page\/galston:351\/623dc53fc67af",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:351~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:351~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/201"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/202",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 203"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/202\/page\/galston:591",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/202\/page\/galston:591\/623dc5403286a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:591~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:591~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/202"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/203",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 204"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/203\/page\/galston:350",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/203\/page\/galston:350\/623dc5409236c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:350~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:350~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/203"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/204",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 205"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/204\/page\/galston:590",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/204\/page\/galston:590\/623dc540f21ec",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:590~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:590~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/204"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/205",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 206"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/205\/page\/galston:349",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/205\/page\/galston:349\/623dc5415dfdf",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:349~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:349~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/205"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/206",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 207"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/206\/page\/galston:589",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/206\/page\/galston:589\/623dc541bde8a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:589~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:589~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/206"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/207",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 208"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/207\/page\/galston:348",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/207\/page\/galston:348\/623dc542299c8",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:348~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:348~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/207"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/208",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 209"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/208\/page\/galston:588",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/208\/page\/galston:588\/623dc54289b3e",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:588~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:588~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/208"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/209",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 210"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/209\/page\/galston:347",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/209\/page\/galston:347\/623dc542e9995",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:347~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:347~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/209"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/210",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 211"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/210\/page\/galston:587",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/210\/page\/galston:587\/623dc54355289",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:587~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:587~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/210"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/211",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 212"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/211\/page\/galston:346",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/211\/page\/galston:346\/623dc543b525f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:346~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:346~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/211"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/212",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 213"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/212\/page\/galston:586",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/212\/page\/galston:586\/623dc54421250",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:586~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:586~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/212"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/213",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 214"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/213\/page\/galston:345",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/213\/page\/galston:345\/623dc54480de2",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:345~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:345~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/213"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/214",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 215"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/214\/page\/galston:585",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/214\/page\/galston:585\/623dc544e0920",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:585~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:585~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/214"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/215",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 216"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/215\/page\/galston:344",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/215\/page\/galston:344\/623dc5454c28d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:344~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:344~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/215"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/216",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 217"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/216\/page\/galston:584",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/216\/page\/galston:584\/623dc545abd41",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:584~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:584~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/216"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/217",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 218"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/217\/page\/galston:343",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/217\/page\/galston:343\/623dc54617661",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:343~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:343~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/217"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/218",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 219"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/218\/page\/galston:583",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/218\/page\/galston:583\/623dc546771a3",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:583~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:583~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/218"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/219",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 220"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/219\/page\/galston:342",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/219\/page\/galston:342\/623dc546d707a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:342~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:342~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/219"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/220",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 221"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/220\/page\/galston:582",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/220\/page\/galston:582\/623dc54742a74",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:582~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:582~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/220"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/221",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 222"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/221\/page\/galston:341",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/221\/page\/galston:341\/623dc547a3113",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:341~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:341~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/221"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/222",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 223"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/222\/page\/galston:581",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/222\/page\/galston:581\/623dc5480ee13",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:581~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:581~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/222"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/223",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 224"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/223\/page\/galston:340",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/223\/page\/galston:340\/623dc5486f564",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:340~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:340~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/223"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/224",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 225"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/224\/page\/galston:580",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/224\/page\/galston:580\/623dc548cf39f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:580~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:580~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/224"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/225",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 226"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/225\/page\/galston:339",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/225\/page\/galston:339\/623dc5493b0dd",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:339~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:339~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/225"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/226",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 227"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/226\/page\/galston:579",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/226\/page\/galston:579\/623dc5499b022",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:579~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:579~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/226"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/227",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 228"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/227\/page\/galston:338",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/227\/page\/galston:338\/623dc54a06c85",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:338~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:338~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/227"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/228",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 229"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/228\/page\/galston:578",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/228\/page\/galston:578\/623dc54a66802",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:578~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:578~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/228"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/229",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 230"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/229\/page\/galston:337",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/229\/page\/galston:337\/623dc54ac6369",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:337~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:337~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/229"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/230",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 231"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/230\/page\/galston:577",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/230\/page\/galston:577\/623dc54b31bc1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:577~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:577~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/230"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/231",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 232"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/231\/page\/galston:336",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/231\/page\/galston:336\/623dc54b91747",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:336~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:336~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/231"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/232",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 233"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/232\/page\/galston:576",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/232\/page\/galston:576\/623dc54bf1227",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:576~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:576~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/232"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/233",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 234"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/233\/page\/galston:335",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/233\/page\/galston:335\/623dc54c5cb2c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:335~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:335~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/233"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/234",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 235"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/234\/page\/galston:575",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/234\/page\/galston:575\/623dc54cbc651",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:575~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:575~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/234"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/235",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 236"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/235\/page\/galston:334",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/235\/page\/galston:334\/623dc54d28111",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:334~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:334~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/235"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/236",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 237"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/236\/page\/galston:574",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/236\/page\/galston:574\/623dc54d87ead",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:574~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:574~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/236"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/237",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 238"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/237\/page\/galston:333",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/237\/page\/galston:333\/623dc54de7e1e",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:333~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:333~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/237"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/238",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 239"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/238\/page\/galston:573",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/238\/page\/galston:573\/623dc54e5366d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:573~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:573~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/238"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/239",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 240"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/239\/page\/galston:332",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/239\/page\/galston:332\/623dc54eb32a1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:332~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:332~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/239"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/240",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 241"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/240\/page\/galston:572",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/240\/page\/galston:572\/623dc54f1ec30",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:572~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:572~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/240"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/241",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 242"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/241\/page\/galston:331",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/241\/page\/galston:331\/623dc54f7eaae",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:331~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:331~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/241"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/242",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 243"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/242\/page\/galston:571",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/242\/page\/galston:571\/623dc54fde4ca",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:571~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:571~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/242"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/243",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 244"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/243\/page\/galston:330",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/243\/page\/galston:330\/623dc55049e15",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:330~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:330~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/243"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/244",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 245"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/244\/page\/galston:570",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/244\/page\/galston:570\/623dc550a99d5",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:570~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:570~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/244"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/245",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 246"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/245\/page\/galston:329",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/245\/page\/galston:329\/623dc55115696",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:329~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:329~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/245"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/246",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 247"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/246\/page\/galston:569",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/246\/page\/galston:569\/623dc551751de",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:569~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:569~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/246"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/247",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 248"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/247\/page\/galston:328",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/247\/page\/galston:328\/623dc551d550e",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:328~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:328~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/247"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/248",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 249"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/248\/page\/galston:568",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/248\/page\/galston:568\/623dc55241249",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:568~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:568~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/248"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/249",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 250"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/249\/page\/galston:327",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/249\/page\/galston:327\/623dc552a11f7",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:327~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:327~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/249"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/250",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 251"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/250\/page\/galston:567",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/250\/page\/galston:567\/623dc5530d24a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:567~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:567~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/250"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/251",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 252"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/251\/page\/galston:326",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/251\/page\/galston:326\/623dc5536d53b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:326~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:326~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/251"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/252",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 253"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/252\/page\/galston:566",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/252\/page\/galston:566\/623dc553cd4e2",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:566~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:566~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/252"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/253",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 254"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/253\/page\/galston:325",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/253\/page\/galston:325\/623dc554394d8",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:325~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:325~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/253"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/254",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 255"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/254\/page\/galston:565",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/254\/page\/galston:565\/623dc554993f6",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:565~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:565~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/254"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/255",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 256"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/255\/page\/galston:324",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/255\/page\/galston:324\/623dc55504e66",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:324~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:324~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/255"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/256",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 257"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/256\/page\/galston:564",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/256\/page\/galston:564\/623dc55565306",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:564~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:564~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/256"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/257",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 258"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/257\/page\/galston:323",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/257\/page\/galston:323\/623dc555c5405",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:323~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:323~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/257"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/258",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 259"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/258\/page\/galston:563",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/258\/page\/galston:563\/623dc5563109f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:563~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:563~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/258"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/259",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 260"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/259\/page\/galston:322",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/259\/page\/galston:322\/623dc55690f65",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:322~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:322~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/259"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/260",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 261"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/260\/page\/galston:562",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/260\/page\/galston:562\/623dc556f0b0e",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:562~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:562~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/260"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/261",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 262"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/261\/page\/galston:321",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/261\/page\/galston:321\/623dc5575c450",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:321~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:321~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/261"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/262",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 263"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/262\/page\/galston:561",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/262\/page\/galston:561\/623dc557bbee4",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:561~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:561~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/262"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/263",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 264"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/263\/page\/galston:320",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/263\/page\/galston:320\/623dc5582778f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:320~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:320~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/263"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/264",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 265"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/264\/page\/galston:560",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/264\/page\/galston:560\/623dc5588738d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:560~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:560~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/264"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/265",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 266"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/265\/page\/galston:319",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/265\/page\/galston:319\/623dc558e6e99",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:319~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:319~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/265"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/266",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 267"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/266\/page\/galston:559",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/266\/page\/galston:559\/623dc55952f06",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:559~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:559~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/266"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/267",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 268"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/267\/page\/galston:318",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/267\/page\/galston:318\/623dc559b2b2c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:318~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:318~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/267"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/268",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 269"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/268\/page\/galston:558",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/268\/page\/galston:558\/623dc55a1e345",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:558~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:558~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/268"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/269",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 270"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/269\/page\/galston:317",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/269\/page\/galston:317\/623dc55a7defa",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:317~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:317~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/269"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/270",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 271"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/270\/page\/galston:557",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/270\/page\/galston:557\/623dc55add9df",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:557~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:557~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/270"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/271",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 272"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/271\/page\/galston:316",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/271\/page\/galston:316\/623dc55b4925e",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:316~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:316~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/271"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/272",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 273"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/272\/page\/galston:556",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/272\/page\/galston:556\/623dc55ba920c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:556~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:556~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/272"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/273",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 274"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/273\/page\/galston:315",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/273\/page\/galston:315\/623dc55c14b9b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:315~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:315~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/273"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/274",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 275"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/274\/page\/galston:555",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/274\/page\/galston:555\/623dc55c7466e",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:555~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:555~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/274"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/275",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 276"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/275\/page\/galston:314",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/275\/page\/galston:314\/623dc55cd4627",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:314~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:314~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/275"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/276",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 277"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/276\/page\/galston:554",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/276\/page\/galston:554\/623dc55d40244",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:554~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:554~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/276"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/277",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 278"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/277\/page\/galston:313",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/277\/page\/galston:313\/623dc55d9fda5",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:313~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:313~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/277"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/278",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 279"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/278\/page\/galston:553",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/278\/page\/galston:553\/623dc55e0b75b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:553~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:553~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/278"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/279",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 280"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/279\/page\/galston:312",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/279\/page\/galston:312\/623dc55e6b5fa",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:312~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:312~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/279"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/280",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 281"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/280\/page\/galston:552",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/280\/page\/galston:552\/623dc55ecb146",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:552~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:552~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/280"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/281",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 282"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/281\/page\/galston:311",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/281\/page\/galston:311\/623dc55f36d0f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:311~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:311~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/281"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/282",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 283"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/282\/page\/galston:551",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/282\/page\/galston:551\/623dc55f96d48",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:551~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:551~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/282"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/283",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 284"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/283\/page\/galston:310",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/283\/page\/galston:310\/623dc56002a59",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:310~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:310~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/283"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/284",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 285"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/284\/page\/galston:550",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/284\/page\/galston:550\/623dc560625fc",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:550~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:550~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/284"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/285",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 286"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/285\/page\/galston:309",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/285\/page\/galston:309\/623dc560c1fe0",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:309~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:309~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/285"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/286",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 287"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/286\/page\/galston:549",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/286\/page\/galston:549\/623dc5612d99f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:549~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:549~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/286"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/287",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 288"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/287\/page\/galston:308",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/287\/page\/galston:308\/623dc5618d477",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:308~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:308~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/287"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/288",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 289"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/288\/page\/galston:548",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/288\/page\/galston:548\/623dc561ed0c6",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:548~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:548~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/288"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/289",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 290"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/289\/page\/galston:307",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/289\/page\/galston:307\/623dc56259157",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:307~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:307~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/289"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/290",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 291"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/290\/page\/galston:547",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/290\/page\/galston:547\/623dc562b9441",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:547~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:547~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/290"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/291",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 292"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/291\/page\/galston:306",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/291\/page\/galston:306\/623dc56324c39",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:306~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:306~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/291"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/292",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 293"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/292\/page\/galston:546",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/292\/page\/galston:546\/623dc56384be6",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:546~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:546~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/292"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/293",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 294"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/293\/page\/galston:305",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/293\/page\/galston:305\/623dc563e46dd",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:305~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:305~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/293"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/294",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 295"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/294\/page\/galston:545",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/294\/page\/galston:545\/623dc5644ffab",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:545~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:545~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/294"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/295",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 296"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/295\/page\/galston:304",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/295\/page\/galston:304\/623dc564afc3b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:304~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:304~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/295"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/296",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 297"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/296\/page\/galston:544",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/296\/page\/galston:544\/623dc5651b444",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:544~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:544~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/296"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/297",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 298"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/297\/page\/galston:303",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/297\/page\/galston:303\/623dc5657afcc",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:303~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:303~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/297"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/298",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 299"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/298\/page\/galston:543",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/298\/page\/galston:543\/623dc565dab5d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:543~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:543~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/298"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/299",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 300"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/299\/page\/galston:302",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/299\/page\/galston:302\/623dc566464aa",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:302~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:302~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/299"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/300",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 301"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/300\/page\/galston:542",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/300\/page\/galston:542\/623dc566a5eef",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:542~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:542~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/300"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/301",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 302"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/301\/page\/galston:301",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/301\/page\/galston:301\/623dc56711efc",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:301~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:301~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/301"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/302",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 303"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/302\/page\/galston:541",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/302\/page\/galston:541\/623dc56772030",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:541~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:541~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/302"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/303",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 304"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/303\/page\/galston:300",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/303\/page\/galston:300\/623dc567d227c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:300~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:300~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/303"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/304",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 305"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/304\/page\/galston:540",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/304\/page\/galston:540\/623dc5683dbc9",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:540~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:540~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/304"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/305",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 306"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/305\/page\/galston:299",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/305\/page\/galston:299\/623dc5689d563",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:299~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:299~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/305"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/306",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 307"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/306\/page\/galston:539",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/306\/page\/galston:539\/623dc56908fd3",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:539~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:539~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/306"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/307",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 308"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/307\/page\/galston:298",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/307\/page\/galston:298\/623dc56968a57",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:298~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:298~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/307"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/308",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 309"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/308\/page\/galston:538",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/308\/page\/galston:538\/623dc569c8567",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:538~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:538~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/308"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/309",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 310"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/309\/page\/galston:297",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/309\/page\/galston:297\/623dc56a342f9",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:297~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:297~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/309"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/310",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 311"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/310\/page\/galston:537",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/310\/page\/galston:537\/623dc56a93e49",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:537~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:537~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/310"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/311",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 312"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/311\/page\/galston:296",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/311\/page\/galston:296\/623dc56af39b4",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:296~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:296~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/311"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/312",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 313"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/312\/page\/galston:536",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/312\/page\/galston:536\/623dc56b5f1ff",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:536~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:536~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/312"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/313",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 314"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/313\/page\/galston:295",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/313\/page\/galston:295\/623dc56bbee6c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:295~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:295~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/313"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/314",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 315"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/314\/page\/galston:535",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/314\/page\/galston:535\/623dc56c2a691",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:535~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:535~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/314"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/315",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 316"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/315\/page\/galston:294",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/315\/page\/galston:294\/623dc56c8a61d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:294~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:294~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/315"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/316",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 317"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/316\/page\/galston:534",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/316\/page\/galston:534\/623dc56cea054",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:534~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:534~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/316"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/317",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 318"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/317\/page\/galston:293",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/317\/page\/galston:293\/623dc56d55a7c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:293~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:293~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/317"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/318",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 319"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/318\/page\/galston:533",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/318\/page\/galston:533\/623dc56db55e9",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:533~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:533~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/318"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/319",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 320"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/319\/page\/galston:292",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/319\/page\/galston:292\/623dc56e20e75",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:292~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:292~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/319"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/320",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 321"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/320\/page\/galston:532",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/320\/page\/galston:532\/623dc56e80e72",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:532~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:532~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/320"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/321",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 322"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/321\/page\/galston:291",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/321\/page\/galston:291\/623dc56ee0973",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:291~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:291~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/321"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/322",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 323"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/322\/page\/galston:531",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/322\/page\/galston:531\/623dc56f4c4ee",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:531~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:531~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/322"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/323",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 324"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/323\/page\/galston:290",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/323\/page\/galston:290\/623dc56fac14f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:290~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:290~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/323"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/324",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 325"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/324\/page\/galston:530",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/324\/page\/galston:530\/623dc57017973",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:530~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:530~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/324"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/325",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 326"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/325\/page\/galston:289",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/325\/page\/galston:289\/623dc57077506",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:289~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:289~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/325"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/326",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 327"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/326\/page\/galston:529",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/326\/page\/galston:529\/623dc570d750a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:529~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:529~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/326"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/327",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 328"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/327\/page\/galston:288",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/327\/page\/galston:288\/623dc571434c4",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:288~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:288~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/327"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/328",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 329"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/328\/page\/galston:528",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/328\/page\/galston:528\/623dc571a2fde",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:528~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:528~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/328"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/329",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 330"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/329\/page\/galston:287",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/329\/page\/galston:287\/623dc5720ed58",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:287~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:287~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/329"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/330",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 331"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/330\/page\/galston:527",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/330\/page\/galston:527\/623dc5726f09b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:527~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:527~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/330"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/331",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 332"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/331\/page\/galston:286",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/331\/page\/galston:286\/623dc572ceca1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:286~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:286~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/331"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/332",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 333"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/332\/page\/galston:526",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/332\/page\/galston:526\/623dc5733b202",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:526~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:526~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/332"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/333",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 334"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/333\/page\/galston:285",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/333\/page\/galston:285\/623dc5739aec2",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:285~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:285~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/333"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/334",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 335"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/334\/page\/galston:525",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/334\/page\/galston:525\/623dc5740688d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:525~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:525~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/334"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/335",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 336"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/335\/page\/galston:284",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/335\/page\/galston:284\/623dc5746682b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:284~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:284~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/335"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/336",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 337"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/336\/page\/galston:524",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/336\/page\/galston:524\/623dc574c62d8",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:524~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:524~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/336"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/337",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 338"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/337\/page\/galston:283",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/337\/page\/galston:283\/623dc57532662",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:283~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:283~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/337"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/338",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 339"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/338\/page\/galston:523",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/338\/page\/galston:523\/623dc575922b9",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:523~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:523~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/338"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/339",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 340"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/339\/page\/galston:282",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/339\/page\/galston:282\/623dc575f1ed9",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:282~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:282~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/339"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/340",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 341"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/340\/page\/galston:522",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/340\/page\/galston:522\/623dc5765db36",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:522~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:522~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/340"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/341",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 342"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/341\/page\/galston:281",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/341\/page\/galston:281\/623dc576bd5a6",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:281~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:281~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/341"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/342",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 343"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/342\/page\/galston:521",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/342\/page\/galston:521\/623dc57729388",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:521~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:521~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/342"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/343",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 344"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/343\/page\/galston:280",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/343\/page\/galston:280\/623dc577895b7",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:280~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:280~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/343"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/344",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 345"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/344\/page\/galston:520",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/344\/page\/galston:520\/623dc577e98f6",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:520~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:520~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/344"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/345",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 346"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/345\/page\/galston:279",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/345\/page\/galston:279\/623dc57855a85",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:279~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:279~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/345"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/346",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 347"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/346\/page\/galston:519",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/346\/page\/galston:519\/623dc578b58ee",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:519~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:519~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/346"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/347",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 348"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/347\/page\/galston:278",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/347\/page\/galston:278\/623dc5792126f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:278~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:278~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/347"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/348",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 349"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/348\/page\/galston:518",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/348\/page\/galston:518\/623dc579838c8",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:518~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:518~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/348"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/349",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 350"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/349\/page\/galston:277",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/349\/page\/galston:277\/623dc579e37b2",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:277~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:277~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/349"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/350",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 351"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/350\/page\/galston:517",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/350\/page\/galston:517\/623dc57a4efd2",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:517~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:517~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/350"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/351",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 352"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/351\/page\/galston:276",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/351\/page\/galston:276\/623dc57aaf3c9",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:276~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:276~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/351"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/352",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 353"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/352\/page\/galston:516",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/352\/page\/galston:516\/623dc57b1b8a7",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:516~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:516~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/352"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/353",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 354"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/353\/page\/galston:275",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/353\/page\/galston:275\/623dc57b7bb96",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:275~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:275~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/353"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/354",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 355"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/354\/page\/galston:515",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/354\/page\/galston:515\/623dc57bdba12",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:515~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:515~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/354"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/355",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 356"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/355\/page\/galston:274",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/355\/page\/galston:274\/623dc57c477e3",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:274~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:274~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/355"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/356",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 357"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/356\/page\/galston:514",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/356\/page\/galston:514\/623dc57ca7284",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:514~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:514~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/356"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/357",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 358"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/357\/page\/galston:273",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/357\/page\/galston:273\/623dc57d12ae0",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:273~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:273~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/357"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/358",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 359"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/358\/page\/galston:513",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/358\/page\/galston:513\/623dc57d72772",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:513~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:513~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/358"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/359",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 360"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/359\/page\/galston:272",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/359\/page\/galston:272\/623dc57dd25d2",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:272~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:272~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/359"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/360",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 361"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/360\/page\/galston:512",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/360\/page\/galston:512\/623dc57e3e626",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:512~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:512~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/360"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/361",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 362"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/361\/page\/galston:271",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/361\/page\/galston:271\/623dc57e9e6fb",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:271~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:271~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/361"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/362",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 363"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/362\/page\/galston:511",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/362\/page\/galston:511\/623dc57f0ae15",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:511~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:511~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/362"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/363",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 364"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/363\/page\/galston:270",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/363\/page\/galston:270\/623dc57f6b173",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:270~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:270~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/363"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/364",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 365"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/364\/page\/galston:510",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/364\/page\/galston:510\/623dc57fcb14d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:510~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:510~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/364"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/365",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 366"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/365\/page\/galston:269",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/365\/page\/galston:269\/623dc58036a55",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:269~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:269~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/365"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/366",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 367"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/366\/page\/galston:509",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/366\/page\/galston:509\/623dc58097feb",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:509~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:509~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/366"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/367",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 368"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/367\/page\/galston:268",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/367\/page\/galston:268\/623dc581039e1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:268~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:268~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/367"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/368",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 369"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/368\/page\/galston:508",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/368\/page\/galston:508\/623dc58163499",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:508~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:508~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/368"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/369",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 370"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/369\/page\/galston:267",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/369\/page\/galston:267\/623dc581c343e",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:267~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:267~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/369"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/370",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 371"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/370\/page\/galston:507",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/370\/page\/galston:507\/623dc5822ee7a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:507~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:507~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/370"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/371",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 372"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/371\/page\/galston:266",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/371\/page\/galston:266\/623dc5828ec9f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:266~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:266~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/371"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/372",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 373"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/372\/page\/galston:506",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/372\/page\/galston:506\/623dc582eef7d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:506~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:506~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/372"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/373",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 374"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/373\/page\/galston:265",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/373\/page\/galston:265\/623dc5835a7ab",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:265~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:265~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/373"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/374",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 375"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/374\/page\/galston:505",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/374\/page\/galston:505\/623dc583ba825",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:505~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:505~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/374"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/375",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 376"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/375\/page\/galston:264",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/375\/page\/galston:264\/623dc58426bec",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:264~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:264~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/375"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/376",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 377"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/376\/page\/galston:504",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/376\/page\/galston:504\/623dc58486cb7",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:504~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:504~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/376"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/377",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 378"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/377\/page\/galston:263",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/377\/page\/galston:263\/623dc584e6f2b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:263~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:263~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/377"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/378",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 379"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/378\/page\/galston:503",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/378\/page\/galston:503\/623dc58552fba",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:503~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:503~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/378"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/379",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 380"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/379\/page\/galston:262",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/379\/page\/galston:262\/623dc585b2a56",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:262~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:262~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/379"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/380",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 381"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/380\/page\/galston:502",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/380\/page\/galston:502\/623dc5861e837",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:502~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:502~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/380"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/381",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 382"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/381\/page\/galston:261",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/381\/page\/galston:261\/623dc5867e68f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:261~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:261~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/381"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/382",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 383"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/382\/page\/galston:501",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/382\/page\/galston:501\/623dc586de285",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:501~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:501~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/382"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/383",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 384"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/383\/page\/galston:260",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/383\/page\/galston:260\/623dc5874a3be",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:260~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:260~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/383"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/384",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 385"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/384\/page\/galston:500",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/384\/page\/galston:500\/623dc587a9df1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:500~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:500~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/384"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/385",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 386"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/385\/page\/galston:259",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/385\/page\/galston:259\/623dc588156e7",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:259~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:259~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/385"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/386",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 387"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/386\/page\/galston:499",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/386\/page\/galston:499\/623dc58876297",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:499~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:499~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/386"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/387",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 388"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/387\/page\/galston:258",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/387\/page\/galston:258\/623dc588d61be",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:258~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:258~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/387"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/388",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 389"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/388\/page\/galston:498",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/388\/page\/galston:498\/623dc58941be8",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:498~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:498~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/388"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/389",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 390"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/389\/page\/galston:257",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/389\/page\/galston:257\/623dc589a1939",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:257~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:257~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/389"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/390",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 391"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/390\/page\/galston:497",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/390\/page\/galston:497\/623dc58a0d229",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:497~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:497~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/390"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/391",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 392"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/391\/page\/galston:256",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/391\/page\/galston:256\/623dc58a6d31d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:256~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:256~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/391"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/392",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 393"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/392\/page\/galston:496",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/392\/page\/galston:496\/623dc58acd157",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:496~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:496~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/392"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/393",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 394"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/393\/page\/galston:255",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/393\/page\/galston:255\/623dc58b395df",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:255~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:255~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/393"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/394",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 395"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/394\/page\/galston:495",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/394\/page\/galston:495\/623dc58b99cbb",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:495~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:495~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/394"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/395",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 396"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/395\/page\/galston:217",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/395\/page\/galston:217\/623dc58c055ed",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:217~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:217~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/395"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/396",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 397"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/396\/page\/galston:494",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/396\/page\/galston:494\/623dc58c654c6",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:494~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:494~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/396"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/397",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 398"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/397\/page\/galston:254",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/397\/page\/galston:254\/623dc58cc58bb",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:254~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:254~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/397"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/398",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 399"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/398\/page\/galston:216",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/398\/page\/galston:216\/623dc58d31429",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:216~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:216~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/398"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/399",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 400"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/399\/page\/galston:253",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/399\/page\/galston:253\/623dc58d913eb",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:253~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:253~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/399"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/400",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 401"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/400\/page\/galston:493",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/400\/page\/galston:493\/623dc58df1314",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:493~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:493~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/400"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/401",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 402"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/401\/page\/galston:215",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/401\/page\/galston:215\/623dc58e5d40b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:215~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:215~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/401"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/402",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 403"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/402\/page\/galston:180",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/402\/page\/galston:180\/623dc58ebd330",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:180~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:180~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/402"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/403",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 404"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/403\/page\/galston:252",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/403\/page\/galston:252\/623dc58f2939d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:252~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:252~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/403"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/404",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 405"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/404\/page\/galston:492",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/404\/page\/galston:492\/623dc58f892b3",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:492~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:492~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/404"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/405",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 406"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/405\/page\/galston:214",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/405\/page\/galston:214\/623dc58fe906b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:214~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:214~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/405"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/406",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 407"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/406\/page\/galston:491",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/406\/page\/galston:491\/623dc590551ed",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:491~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:491~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/406"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/407",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 408"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/407\/page\/galston:251",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/407\/page\/galston:251\/623dc590b4e00",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:251~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:251~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/407"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/408",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 409"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/408\/page\/galston:490",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/408\/page\/galston:490\/623dc5912069d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:490~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:490~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/408"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/409",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 410"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/409\/page\/galston:213",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/409\/page\/galston:213\/623dc5918096c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:213~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:213~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/409"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/410",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 411"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/410\/page\/galston:489",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/410\/page\/galston:489\/623dc591e090d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:489~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:489~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/410"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/411",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 412"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/411\/page\/galston:250",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/411\/page\/galston:250\/623dc5924c640",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:250~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:250~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/411"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/412",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 413"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/412\/page\/galston:488",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/412\/page\/galston:488\/623dc592ac58b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:488~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:488~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/412"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/413",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 414"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/413\/page\/galston:212",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/413\/page\/galston:212\/623dc59317efe",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:212~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:212~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/413"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/414",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 415"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/414\/page\/galston:487",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/414\/page\/galston:487\/623dc593779e1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:487~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:487~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/414"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/415",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 416"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/415\/page\/galston:249",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/415\/page\/galston:249\/623dc593d7920",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:249~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:249~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/415"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/416",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 417"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/416\/page\/galston:486",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/416\/page\/galston:486\/623dc59443d14",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:486~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:486~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/416"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/417",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 418"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/417\/page\/galston:211",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/417\/page\/galston:211\/623dc594a405c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:211~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:211~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/417"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/418",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 419"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/418\/page\/galston:485",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/418\/page\/galston:485\/623dc59510504",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:485~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:485~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/418"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/419",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 420"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/419\/page\/galston:248",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/419\/page\/galston:248\/623dc595704fc",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:248~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:248~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/419"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/420",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 421"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/420\/page\/galston:484",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/420\/page\/galston:484\/623dc595d0807",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:484~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:484~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/420"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/421",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 422"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/421\/page\/galston:210",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/421\/page\/galston:210\/623dc5963c960",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:210~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:210~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/421"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/422",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 423"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/422\/page\/galston:483",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/422\/page\/galston:483\/623dc5969c78c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:483~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:483~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/422"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/423",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 424"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/423\/page\/galston:247",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/423\/page\/galston:247\/623dc5970864a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:247~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:247~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/423"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/424",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 425"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/424\/page\/galston:482",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/424\/page\/galston:482\/623dc59768795",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:482~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:482~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/424"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/425",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 426"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/425\/page\/galston:209",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/425\/page\/galston:209\/623dc597c862c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:209~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:209~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/425"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/426",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 427"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/426\/page\/galston:481",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/426\/page\/galston:481\/623dc598341d9",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:481~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:481~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/426"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/427",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 428"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/427\/page\/galston:246",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/427\/page\/galston:246\/623dc59894242",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:246~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:246~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/427"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/428",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 429"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/428\/page\/galston:480",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/428\/page\/galston:480\/623dc598f4102",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:480~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:480~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/428"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/429",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 430"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/429\/page\/galston:208",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/429\/page\/galston:208\/623dc5995ff37",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:208~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:208~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/429"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/430",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 431"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/430\/page\/galston:479",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/430\/page\/galston:479\/623dc599c0140",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:479~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:479~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/430"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/431",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 432"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/431\/page\/galston:245",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/431\/page\/galston:245\/623dc59a2c1ea",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:245~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:245~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/431"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/432",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 433"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/432\/page\/galston:478",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/432\/page\/galston:478\/623dc59a8ca72",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:478~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:478~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/432"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/433",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 434"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/433\/page\/galston:207",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/433\/page\/galston:207\/623dc59aecfc7",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:207~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:207~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/433"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/434",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 435"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/434\/page\/galston:477",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/434\/page\/galston:477\/623dc59b59490",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:477~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:477~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/434"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/435",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 436"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/435\/page\/galston:244",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/435\/page\/galston:244\/623dc59bb9837",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:244~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:244~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/435"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/436",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 437"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/436\/page\/galston:476",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/436\/page\/galston:476\/623dc59c25136",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:476~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:476~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/436"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/437",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 438"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/437\/page\/galston:206",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/437\/page\/galston:206\/623dc59c853b6",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:206~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:206~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/437"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/438",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 439"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/438\/page\/galston:475",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/438\/page\/galston:475\/623dc59ce4f75",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:475~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:475~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/438"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/439",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 440"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/439\/page\/galston:243",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/439\/page\/galston:243\/623dc59d507fa",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:243~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:243~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/439"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/440",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 441"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/440\/page\/galston:474",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/440\/page\/galston:474\/623dc59db034a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:474~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:474~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/440"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/441",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 442"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/441\/page\/galston:205",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/441\/page\/galston:205\/623dc59e1bcfb",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:205~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:205~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/441"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/442",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 443"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/442\/page\/galston:473",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/442\/page\/galston:473\/623dc59e7bb70",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:473~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:473~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/442"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/443",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 444"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/443\/page\/galston:242",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/443\/page\/galston:242\/623dc59edb69a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:242~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:242~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/443"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/444",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 445"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/444\/page\/galston:472",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/444\/page\/galston:472\/623dc59f474d2",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:472~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:472~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/444"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/445",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 446"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/445\/page\/galston:204",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/445\/page\/galston:204\/623dc59fa7671",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:204~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:204~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/445"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/446",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 447"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/446\/page\/galston:471",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/446\/page\/galston:471\/623dc5a012fb8",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:471~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:471~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/446"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/447",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 448"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/447\/page\/galston:241",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/447\/page\/galston:241\/623dc5a073301",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:241~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:241~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/447"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/448",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 449"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/448\/page\/galston:470",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/448\/page\/galston:470\/623dc5a0d2eec",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:470~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:470~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/448"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/449",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 450"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/449\/page\/galston:203",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/449\/page\/galston:203\/623dc5a13f309",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:203~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:203~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/449"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/450",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 451"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/450\/page\/galston:469",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/450\/page\/galston:469\/623dc5a19f0e5",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:469~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:469~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/450"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/451",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 452"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/451\/page\/galston:240",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/451\/page\/galston:240\/623dc5a20afb0",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:240~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:240~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/451"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/452",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 453"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/452\/page\/galston:468",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/452\/page\/galston:468\/623dc5a26aa4d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:468~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:468~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/452"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/453",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 454"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/453\/page\/galston:202",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/453\/page\/galston:202\/623dc5a2ca545",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:202~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:202~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/453"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/454",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 455"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/454\/page\/galston:467",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/454\/page\/galston:467\/623dc5a335e9f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:467~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:467~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/454"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/455",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 456"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/455\/page\/galston:239",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/455\/page\/galston:239\/623dc5a395e4f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:239~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:239~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/455"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/456",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 457"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/456\/page\/galston:466",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/456\/page\/galston:466\/623dc5a401e21",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:466~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:466~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/456"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/457",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 458"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/457\/page\/galston:201",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/457\/page\/galston:201\/623dc5a461e71",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:201~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:201~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/457"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/458",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 459"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/458\/page\/galston:465",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/458\/page\/galston:465\/623dc5a4c20d7",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:465~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:465~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/458"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/459",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 460"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/459\/page\/galston:238",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/459\/page\/galston:238\/623dc5a52e1ff",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:238~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:238~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/459"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/460",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 461"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/460\/page\/galston:464",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/460\/page\/galston:464\/623dc5a58e440",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:464~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:464~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/460"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/461",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 462"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/461\/page\/galston:200",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/461\/page\/galston:200\/623dc5a5ee364",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:200~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:200~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/461"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/462",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 463"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/462\/page\/galston:463",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/462\/page\/galston:463\/623dc5a659ffe",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:463~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:463~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/462"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/463",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 464"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/463\/page\/galston:237",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/463\/page\/galston:237\/623dc5a6ba037",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:237~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:237~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/463"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/464",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 465"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/464\/page\/galston:462",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/464\/page\/galston:462\/623dc5a725939",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:462~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:462~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/464"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/465",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 466"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/465\/page\/galston:199",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/465\/page\/galston:199\/623dc5a785af4",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:199~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:199~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/465"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/466",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 467"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/466\/page\/galston:461",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/466\/page\/galston:461\/623dc5a7e5b2b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:461~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:461~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/466"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/467",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 468"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/467\/page\/galston:236",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/467\/page\/galston:236\/623dc5a851786",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:236~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:236~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/467"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/468",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 469"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/468\/page\/galston:460",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/468\/page\/galston:460\/623dc5a8b1aa1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:460~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:460~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/468"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/469",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 470"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/469\/page\/galston:198",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/469\/page\/galston:198\/623dc5a91d419",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:198~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:198~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/469"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/470",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 471"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/470\/page\/galston:459",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/470\/page\/galston:459\/623dc5a97ced0",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:459~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:459~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/470"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/471",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 472"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/471\/page\/galston:235",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/471\/page\/galston:235\/623dc5a9dd1b7",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:235~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:235~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/471"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/472",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 473"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/472\/page\/galston:458",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/472\/page\/galston:458\/623dc5aa48f40",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:458~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:458~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/472"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/473",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 474"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/473\/page\/galston:197",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/473\/page\/galston:197\/623dc5aaa8e46",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:197~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:197~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/473"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/474",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 475"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/474\/page\/galston:457",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/474\/page\/galston:457\/623dc5ab14ba1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:457~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:457~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/474"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/475",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 476"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/475\/page\/galston:234",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/475\/page\/galston:234\/623dc5ab747b5",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:234~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:234~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/475"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/476",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 477"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/476\/page\/galston:456",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/476\/page\/galston:456\/623dc5abd4a76",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:456~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:456~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/476"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/477",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 478"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/477\/page\/galston:196",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/477\/page\/galston:196\/623dc5ac40e5e",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:196~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:196~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/477"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/478",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 479"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/478\/page\/galston:455",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/478\/page\/galston:455\/623dc5aca15be",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:455~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:455~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/478"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/479",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 480"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/479\/page\/galston:233",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/479\/page\/galston:233\/623dc5ad0d227",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:233~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:233~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/479"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/480",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 481"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/480\/page\/galston:454",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/480\/page\/galston:454\/623dc5ad6d8f2",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:454~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:454~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/480"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/481",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 482"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/481\/page\/galston:195",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/481\/page\/galston:195\/623dc5adcd836",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:195~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:195~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/481"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/482",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 483"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/482\/page\/galston:450",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/482\/page\/galston:450\/623dc5ae394f1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:450~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:450~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/482"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/483",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 484"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/483\/page\/galston:232",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/483\/page\/galston:232\/623dc5ae993cb",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:232~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:232~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/483"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/484",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 485"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/484\/page\/galston:449",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/484\/page\/galston:449\/623dc5af04dea",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:449~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:449~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/484"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/485",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 486"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/485\/page\/galston:194",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/485\/page\/galston:194\/623dc5af6502b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:194~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:194~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/485"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/486",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 487"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/486\/page\/galston:220",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/486\/page\/galston:220\/623dc5afc50c2",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:220~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:220~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/486"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/487",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 488"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/487\/page\/galston:231",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/487\/page\/galston:231\/623dc5b03104a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:231~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:231~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/487"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/488",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 489"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/488\/page\/galston:228",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/488\/page\/galston:228\/623dc5b090b52",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:228~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:228~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/488"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/489",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 490"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/489\/page\/galston:193",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/489\/page\/galston:193\/623dc5b0f0ac0",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:193~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:193~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/489"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/490",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 491"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/490\/page\/galston:453",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/490\/page\/galston:453\/623dc5b15c32b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:453~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:453~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/490"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/491",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 492"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/491\/page\/galston:230",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/491\/page\/galston:230\/623dc5b1bbe3d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:230~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:230~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/491"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/492",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 493"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/492\/page\/galston:182",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/492\/page\/galston:182\/623dc5b227baf",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:182~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:182~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/492"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/493",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 494"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/493\/page\/galston:192",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/493\/page\/galston:192\/623dc5b2875f8",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:192~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:192~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/493"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/494",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 495"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/494\/page\/galston:452",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/494\/page\/galston:452\/623dc5b2e72ce",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:452~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:452~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/494"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/495",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 496"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/495\/page\/galston:229",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/495\/page\/galston:229\/623dc5b352fff",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:229~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:229~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/495"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/496",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 497"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/496\/page\/galston:451",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/496\/page\/galston:451\/623dc5b3b2d90",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:451~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:451~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/496"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/497",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 498"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/497\/page\/galston:191",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/497\/page\/galston:191\/623dc5b41e750",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:191~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:191~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/497"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/498",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch:  page 499"
+        ]
+      },
+      "width": 6192,
+      "height": 8256,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/498\/page\/galston:712",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/498\/page\/galston:712\/623dc5b47e5e5",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:712~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6192,
+                  "height": 8256,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:712~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178\/canvas\/498"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "seeAlso": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/collections\/islandora\/object\/galston%3A178\/datastream\/MODS",
+      "type": "Dataset",
+      "label": {
+        "en": [
+          "Bibliographic Description in MODS"
+        ]
+      },
+      "format": "application\/xml",
+      "profile": "http:\/\/www.loc.gov\/standards\/mods\/v3\/mods-3-5.xsd"
+    }
+  ],
+  "behavior": [
+    "paged"
+  ]
+}

--- a/iiif/galston_178.json
+++ b/iiif/galston_178.json
@@ -2,7 +2,7 @@
   "@context": [
     "https:\/\/iiif.io\/api\/presentation\/3\/context.json"
   ],
-  "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/178",
+  "id": "https:\/\/digital.lib.utk.edu\/static\/iiif\/galston_178.json",
   "type": "Manifest",
   "label": {
     "en": [

--- a/iiif/galston_680.json
+++ b/iiif/galston_680.json
@@ -2,7 +2,7 @@
   "@context": [
     "https:\/\/iiif.io\/api\/presentation\/3\/context.json"
   ],
-  "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/680",
+  "id": "https:\/\/digital.lib.utk.edu\/static\/iiif\/galston_680.json",
   "type": "Manifest",
   "label": {
     "en": [

--- a/iiif/galston_680.json
+++ b/iiif/galston_680.json
@@ -1,0 +1,201 @@
+{
+  "@context": [
+    "https:\/\/iiif.io\/api\/presentation\/3\/context.json"
+  ],
+  "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/680",
+  "type": "Manifest",
+  "label": {
+    "en": [
+      "Studio portrait of Gottfried Galston by Eugene Smith, 1912"
+    ]
+  },
+  "summary": {
+    "en": [
+      "Photograph taken in Munich, Germany, with ornamental arched border incorporating the text \"Gottfried Galston\" and a signature. A handwritten note on the reverse attributes the photograph to Eugene Smith, March 1912 (?). Note that Eugene Smith is also known as Frank Eugene and Frank Eugene Smith."
+    ]
+  },
+  "metadata": [
+    {
+      "label": {
+        "en": [
+          "Date"
+        ]
+      },
+      "value": {
+        "en": [
+          "circa 1912",
+          "circa 1912"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Format"
+        ]
+      },
+      "value": {
+        "en": [
+          "photographs"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Subject"
+        ]
+      },
+      "value": {
+        "en": [
+          "Portraits",
+          "Musicians"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Place"
+        ]
+      },
+      "value": {
+        "en": [
+          "Munich"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Description"
+        ]
+      },
+      "value": {
+        "en": [
+          "Photograph taken in Munich, Germany, with ornamental arched border incorporating the text \"Gottfried Galston\" and a signature. A handwritten note on the reverse attributes the photograph to Eugene Smith, March 1912 (?). Note that Eugene Smith is also known as Frank Eugene and Frank Eugene Smith."
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Photographer"
+        ]
+      },
+      "value": {
+        "en": [
+          "Eugene, Frank, 1865-1936"
+        ]
+      }
+    }
+  ],
+  "rights": "http:\/\/rightsstatements.org\/vocab\/NoC-US\/1.0\/",
+  "requiredStatement": {
+    "label": {
+      "en": [
+        "Provided by"
+      ]
+    },
+    "value": {
+      "en": [
+        "University of Tennessee, Knoxville. Libraries"
+      ]
+    }
+  },
+  "provider": [
+    {
+      "id": "https:\/\/www.lib.utk.edu\/about\/",
+      "type": "Agent",
+      "label": {
+        "en": [
+          "University of Tennessee, Knoxville. Libraries"
+        ]
+      },
+      "homepage": [
+        {
+          "id": "https:\/\/www.lib.utk.edu\/",
+          "type": "Text",
+          "label": {
+            "en": [
+              "University of Tennessee Libraries Homepage"
+            ]
+          },
+          "format": "text\/html"
+        }
+      ],
+      "logo": [
+        {
+          "id": "https:\/\/utkdigitalinitiatives.github.io\/iiif-level-0\/ut_libraries_centered\/full\/full\/0\/default.jpg",
+          "type": "Image",
+          "format": "image\/jpeg",
+          "width": 200,
+          "height": 200
+        }
+      ]
+    }
+  ],
+  "thumbnail": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston%3A680~datastream~JP2\/full\/max\/0\/default.jpg",
+      "width": 5600,
+      "height": 7091,
+      "type": "Image",
+      "format": "image\/jpeg"
+    }
+  ],
+  "items": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/680\/canvas\/0",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studio portrait of Gottfried Galston by Eugene Smith, 1912"
+        ]
+      },
+      "width": 5600,
+      "height": 7091,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/680\/canvas\/0\/page\/galston%3A680",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/680\/canvas\/0\/page\/galston%3A680\/623dc5b8f1337",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston%3A680~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 5600,
+                  "height": 7091,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston%3A680~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/680\/canvas\/0"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "seeAlso": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/collections\/islandora\/object\/galston%3A680\/datastream\/MODS",
+      "type": "Dataset",
+      "label": {
+        "en": [
+          "Bibliographic Description in MODS"
+        ]
+      },
+      "format": "application\/xml",
+      "profile": "http:\/\/www.loc.gov\/standards\/mods\/v3\/mods-3-5.xsd"
+    }
+  ]
+}

--- a/iiif/galston_682.json
+++ b/iiif/galston_682.json
@@ -1,0 +1,179 @@
+{
+  "@context": [
+    "https:\/\/iiif.io\/api\/presentation\/3\/context.json"
+  ],
+  "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/682",
+  "type": "Manifest",
+  "label": {
+    "en": [
+      "Portrait of Gottfried Galston during WWI"
+    ]
+  },
+  "summary": {
+    "en": [
+      "Photograph postcard of Gottfried Galston, believed to have been taken ca. 1916, when he served as a Lieutenant in the Austrian Cavalry in World War I."
+    ]
+  },
+  "metadata": [
+    {
+      "label": {
+        "en": [
+          "Date"
+        ]
+      },
+      "value": {
+        "en": [
+          "circa 1916",
+          "circa 1916"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Format"
+        ]
+      },
+      "value": {
+        "en": [
+          "postcards",
+          "photographs"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Subject"
+        ]
+      },
+      "value": {
+        "en": [
+          "Portraits",
+          "Cavalry",
+          "World War, 1914-1918"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Description"
+        ]
+      },
+      "value": {
+        "en": [
+          "Photograph postcard of Gottfried Galston, believed to have been taken ca. 1916, when he served as a Lieutenant in the Austrian Cavalry in World War I."
+        ]
+      }
+    }
+  ],
+  "rights": "http:\/\/rightsstatements.org\/vocab\/UND\/1.0\/",
+  "requiredStatement": {
+    "label": {
+      "en": [
+        "Provided by"
+      ]
+    },
+    "value": {
+      "en": [
+        "University of Tennessee, Knoxville. Libraries"
+      ]
+    }
+  },
+  "provider": [
+    {
+      "id": "https:\/\/www.lib.utk.edu\/about\/",
+      "type": "Agent",
+      "label": {
+        "en": [
+          "University of Tennessee, Knoxville. Libraries"
+        ]
+      },
+      "homepage": [
+        {
+          "id": "https:\/\/www.lib.utk.edu\/",
+          "type": "Text",
+          "label": {
+            "en": [
+              "University of Tennessee Libraries Homepage"
+            ]
+          },
+          "format": "text\/html"
+        }
+      ],
+      "logo": [
+        {
+          "id": "https:\/\/utkdigitalinitiatives.github.io\/iiif-level-0\/ut_libraries_centered\/full\/full\/0\/default.jpg",
+          "type": "Image",
+          "format": "image\/jpeg",
+          "width": 200,
+          "height": 200
+        }
+      ]
+    }
+  ],
+  "thumbnail": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston%3A682~datastream~JP2\/full\/max\/0\/default.jpg",
+      "width": 3640,
+      "height": 5623,
+      "type": "Image",
+      "format": "image\/jpeg"
+    }
+  ],
+  "items": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/682\/canvas\/0",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Portrait of Gottfried Galston during WWI"
+        ]
+      },
+      "width": 3640,
+      "height": 5623,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/682\/canvas\/0\/page\/galston%3A682",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/682\/canvas\/0\/page\/galston%3A682\/623dc5bb4f892",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston%3A682~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3640,
+                  "height": 5623,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston%3A682~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/682\/canvas\/0"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "seeAlso": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/collections\/islandora\/object\/galston%3A682\/datastream\/MODS",
+      "type": "Dataset",
+      "label": {
+        "en": [
+          "Bibliographic Description in MODS"
+        ]
+      },
+      "format": "application\/xml",
+      "profile": "http:\/\/www.loc.gov\/standards\/mods\/v3\/mods-3-5.xsd"
+    }
+  ]
+}

--- a/iiif/galston_682.json
+++ b/iiif/galston_682.json
@@ -2,7 +2,7 @@
   "@context": [
     "https:\/\/iiif.io\/api\/presentation\/3\/context.json"
   ],
-  "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/682",
+  "id": "https:\/\/digital.lib.utk.edu\/static\/iiif\/galston_682.json",
   "type": "Manifest",
   "label": {
     "en": [

--- a/iiif/galston_684.json
+++ b/iiif/galston_684.json
@@ -2,7 +2,7 @@
   "@context": [
     "https:\/\/iiif.io\/api\/presentation\/3\/context.json"
   ],
-  "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/684",
+  "id": "https:\/\/digital.lib.utk.edu\/static\/iiif\/galston_684.json",
   "type": "Manifest",
   "label": {
     "en": [

--- a/iiif/galston_684.json
+++ b/iiif/galston_684.json
@@ -1,0 +1,201 @@
+{
+  "@context": [
+    "https:\/\/iiif.io\/api\/presentation\/3\/context.json"
+  ],
+  "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/684",
+  "type": "Manifest",
+  "label": {
+    "en": [
+      "Studio portrait of Gottfried Galston by Eduard Wasow, 1920"
+    ]
+  },
+  "summary": {
+    "en": [
+      "Atmospheric photo of Gottfried Galston taken in 1920 in Munich, Germany. Galston was approximately 41 at the time of the photo and was living in the city. Eduard Wasow's signature is present at the bottom edge of the photograph."
+    ]
+  },
+  "metadata": [
+    {
+      "label": {
+        "en": [
+          "Date"
+        ]
+      },
+      "value": {
+        "en": [
+          "1920",
+          "1920"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Format"
+        ]
+      },
+      "value": {
+        "en": [
+          "photographs"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Subject"
+        ]
+      },
+      "value": {
+        "en": [
+          "Portraits",
+          "Musicians"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Place"
+        ]
+      },
+      "value": {
+        "en": [
+          "Munich"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Description"
+        ]
+      },
+      "value": {
+        "en": [
+          "Atmospheric photo of Gottfried Galston taken in 1920 in Munich, Germany. Galston was approximately 41 at the time of the photo and was living in the city. Eduard Wasow's signature is present at the bottom edge of the photograph."
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Photographer"
+        ]
+      },
+      "value": {
+        "en": [
+          "Wasow, Eduard"
+        ]
+      }
+    }
+  ],
+  "rights": "http:\/\/rightsstatements.org\/vocab\/NKC\/1.0\/",
+  "requiredStatement": {
+    "label": {
+      "en": [
+        "Provided by"
+      ]
+    },
+    "value": {
+      "en": [
+        "University of Tennessee, Knoxville. Libraries"
+      ]
+    }
+  },
+  "provider": [
+    {
+      "id": "https:\/\/www.lib.utk.edu\/about\/",
+      "type": "Agent",
+      "label": {
+        "en": [
+          "University of Tennessee, Knoxville. Libraries"
+        ]
+      },
+      "homepage": [
+        {
+          "id": "https:\/\/www.lib.utk.edu\/",
+          "type": "Text",
+          "label": {
+            "en": [
+              "University of Tennessee Libraries Homepage"
+            ]
+          },
+          "format": "text\/html"
+        }
+      ],
+      "logo": [
+        {
+          "id": "https:\/\/utkdigitalinitiatives.github.io\/iiif-level-0\/ut_libraries_centered\/full\/full\/0\/default.jpg",
+          "type": "Image",
+          "format": "image\/jpeg",
+          "width": 200,
+          "height": 200
+        }
+      ]
+    }
+  ],
+  "thumbnail": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston%3A684~datastream~JP2\/full\/max\/0\/default.jpg",
+      "width": 5798,
+      "height": 7713,
+      "type": "Image",
+      "format": "image\/jpeg"
+    }
+  ],
+  "items": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/684\/canvas\/0",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studio portrait of Gottfried Galston by Eduard Wasow, 1920"
+        ]
+      },
+      "width": 5798,
+      "height": 7713,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/684\/canvas\/0\/page\/galston%3A684",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/684\/canvas\/0\/page\/galston%3A684\/623dc5bdd80ef",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston%3A684~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 5798,
+                  "height": 7713,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston%3A684~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/684\/canvas\/0"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "seeAlso": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/collections\/islandora\/object\/galston%3A684\/datastream\/MODS",
+      "type": "Dataset",
+      "label": {
+        "en": [
+          "Bibliographic Description in MODS"
+        ]
+      },
+      "format": "application\/xml",
+      "profile": "http:\/\/www.loc.gov\/standards\/mods\/v3\/mods-3-5.xsd"
+    }
+  ]
+}

--- a/iiif/galston_686.json
+++ b/iiif/galston_686.json
@@ -1,0 +1,201 @@
+{
+  "@context": [
+    "https:\/\/iiif.io\/api\/presentation\/3\/context.json"
+  ],
+  "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/686",
+  "type": "Manifest",
+  "label": {
+    "en": [
+      "Studio portrait of Gottfried Galston by Wanda von Debschitz-Kunowski, 1924"
+    ]
+  },
+  "summary": {
+    "en": [
+      "Photograph depicts Gottfried Galston on a bended knee in a striped suit and bowtie. Galston was approximately 44 at the time the photo was taken. Debschitz-Kunowski's signature is present at the bottom edge of the photograph."
+    ]
+  },
+  "metadata": [
+    {
+      "label": {
+        "en": [
+          "Date"
+        ]
+      },
+      "value": {
+        "en": [
+          "circa 1924",
+          "circa 1924"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Format"
+        ]
+      },
+      "value": {
+        "en": [
+          "photographs"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Subject"
+        ]
+      },
+      "value": {
+        "en": [
+          "Portraits",
+          "Musicians"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Place"
+        ]
+      },
+      "value": {
+        "en": [
+          "Berlin"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Description"
+        ]
+      },
+      "value": {
+        "en": [
+          "Photograph depicts Gottfried Galston on a bended knee in a striped suit and bowtie. Galston was approximately 44 at the time the photo was taken. Debschitz-Kunowski's signature is present at the bottom edge of the photograph."
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Photographer"
+        ]
+      },
+      "value": {
+        "en": [
+          "Debschitz-Kunowski, Wanda von"
+        ]
+      }
+    }
+  ],
+  "rights": "http:\/\/rightsstatements.org\/vocab\/NKC\/1.0\/",
+  "requiredStatement": {
+    "label": {
+      "en": [
+        "Provided by"
+      ]
+    },
+    "value": {
+      "en": [
+        "University of Tennessee, Knoxville. Libraries"
+      ]
+    }
+  },
+  "provider": [
+    {
+      "id": "https:\/\/www.lib.utk.edu\/about\/",
+      "type": "Agent",
+      "label": {
+        "en": [
+          "University of Tennessee, Knoxville. Libraries"
+        ]
+      },
+      "homepage": [
+        {
+          "id": "https:\/\/www.lib.utk.edu\/",
+          "type": "Text",
+          "label": {
+            "en": [
+              "University of Tennessee Libraries Homepage"
+            ]
+          },
+          "format": "text\/html"
+        }
+      ],
+      "logo": [
+        {
+          "id": "https:\/\/utkdigitalinitiatives.github.io\/iiif-level-0\/ut_libraries_centered\/full\/full\/0\/default.jpg",
+          "type": "Image",
+          "format": "image\/jpeg",
+          "width": 200,
+          "height": 200
+        }
+      ]
+    }
+  ],
+  "thumbnail": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston%3A686~datastream~JP2\/full\/max\/0\/default.jpg",
+      "width": 5735,
+      "height": 7945,
+      "type": "Image",
+      "format": "image\/jpeg"
+    }
+  ],
+  "items": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/686\/canvas\/0",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studio portrait of Gottfried Galston by Wanda von Debschitz-Kunowski, 1924"
+        ]
+      },
+      "width": 5735,
+      "height": 7945,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/686\/canvas\/0\/page\/galston%3A686",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/686\/canvas\/0\/page\/galston%3A686\/623dc5c0a211c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston%3A686~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 5735,
+                  "height": 7945,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston%3A686~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/686\/canvas\/0"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "seeAlso": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/collections\/islandora\/object\/galston%3A686\/datastream\/MODS",
+      "type": "Dataset",
+      "label": {
+        "en": [
+          "Bibliographic Description in MODS"
+        ]
+      },
+      "format": "application\/xml",
+      "profile": "http:\/\/www.loc.gov\/standards\/mods\/v3\/mods-3-5.xsd"
+    }
+  ]
+}

--- a/iiif/galston_686.json
+++ b/iiif/galston_686.json
@@ -2,7 +2,7 @@
   "@context": [
     "https:\/\/iiif.io\/api\/presentation\/3\/context.json"
   ],
-  "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/686",
+  "id": "https:\/\/digital.lib.utk.edu\/static\/iiif\/galston_686.json",
   "type": "Manifest",
   "label": {
     "en": [

--- a/iiif/galston_692.json
+++ b/iiif/galston_692.json
@@ -1,0 +1,190 @@
+{
+  "@context": [
+    "https:\/\/iiif.io\/api\/presentation\/3\/context.json"
+  ],
+  "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/692",
+  "type": "Manifest",
+  "label": {
+    "en": [
+      "Postcard of Gottfried Galston and Artur Schnabel"
+    ]
+  },
+  "summary": {
+    "en": [
+      "Postcard of Gottfried Galston with pianist Artur Schnabel. The handwritten note above the picture indicates it was taken in Berlin in January 1900. Photographer unknown."
+    ]
+  },
+  "metadata": [
+    {
+      "label": {
+        "en": [
+          "Date"
+        ]
+      },
+      "value": {
+        "en": [
+          "January 2, 1900",
+          "1900-01-02"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Format"
+        ]
+      },
+      "value": {
+        "en": [
+          "photographs",
+          "postcards"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Subject"
+        ]
+      },
+      "value": {
+        "en": [
+          "Portraits, Group",
+          "Musicians"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Place"
+        ]
+      },
+      "value": {
+        "en": [
+          "Berlin"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Description"
+        ]
+      },
+      "value": {
+        "en": [
+          "Postcard of Gottfried Galston with pianist Artur Schnabel. The handwritten note above the picture indicates it was taken in Berlin in January 1900. Photographer unknown."
+        ]
+      }
+    }
+  ],
+  "rights": "http:\/\/rightsstatements.org\/vocab\/NKC\/1.0\/",
+  "requiredStatement": {
+    "label": {
+      "en": [
+        "Provided by"
+      ]
+    },
+    "value": {
+      "en": [
+        "University of Tennessee, Knoxville. Libraries"
+      ]
+    }
+  },
+  "provider": [
+    {
+      "id": "https:\/\/www.lib.utk.edu\/about\/",
+      "type": "Agent",
+      "label": {
+        "en": [
+          "University of Tennessee, Knoxville. Libraries"
+        ]
+      },
+      "homepage": [
+        {
+          "id": "https:\/\/www.lib.utk.edu\/",
+          "type": "Text",
+          "label": {
+            "en": [
+              "University of Tennessee Libraries Homepage"
+            ]
+          },
+          "format": "text\/html"
+        }
+      ],
+      "logo": [
+        {
+          "id": "https:\/\/utkdigitalinitiatives.github.io\/iiif-level-0\/ut_libraries_centered\/full\/full\/0\/default.jpg",
+          "type": "Image",
+          "format": "image\/jpeg",
+          "width": 200,
+          "height": 200
+        }
+      ]
+    }
+  ],
+  "thumbnail": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston%3A692~datastream~JP2\/full\/max\/0\/default.jpg",
+      "width": 5528,
+      "height": 3602,
+      "type": "Image",
+      "format": "image\/jpeg"
+    }
+  ],
+  "items": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/692\/canvas\/0",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Postcard of Gottfried Galston and Artur Schnabel"
+        ]
+      },
+      "width": 5528,
+      "height": 3602,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/692\/canvas\/0\/page\/galston%3A692",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/692\/canvas\/0\/page\/galston%3A692\/623dc5c8d2e7b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston%3A692~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 5528,
+                  "height": 3602,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston%3A692~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/692\/canvas\/0"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "seeAlso": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/collections\/islandora\/object\/galston%3A692\/datastream\/MODS",
+      "type": "Dataset",
+      "label": {
+        "en": [
+          "Bibliographic Description in MODS"
+        ]
+      },
+      "format": "application\/xml",
+      "profile": "http:\/\/www.loc.gov\/standards\/mods\/v3\/mods-3-5.xsd"
+    }
+  ]
+}

--- a/iiif/galston_692.json
+++ b/iiif/galston_692.json
@@ -2,7 +2,7 @@
   "@context": [
     "https:\/\/iiif.io\/api\/presentation\/3\/context.json"
   ],
-  "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/692",
+  "id": "https:\/\/digital.lib.utk.edu\/static\/iiif\/galston_692.json",
   "type": "Manifest",
   "label": {
     "en": [

--- a/iiif/galston_694.json
+++ b/iiif/galston_694.json
@@ -2,7 +2,7 @@
   "@context": [
     "https://iiif.io/api/presentation/3/context.json"
   ],
-  "id": "https://digital.lib.utk.edu/assemble/manifest/galston/694",
+  "id": "https:\/\/digital.lib.utk.edu\/static\/iiif\/galston_694.json",
   "type": "Manifest",
   "label": {
     "en": [

--- a/iiif/galston_696.json
+++ b/iiif/galston_696.json
@@ -2,7 +2,7 @@
   "@context": [
     "https:\/\/iiif.io\/api\/presentation\/3\/context.json"
   ],
-  "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/696",
+  "id": "https:\/\/digital.lib.utk.edu\/static\/iiif\/galston_696.json",
   "type": "Manifest",
   "label": {
     "en": [

--- a/iiif/galston_696.json
+++ b/iiif/galston_696.json
@@ -1,0 +1,201 @@
+{
+  "@context": [
+    "https:\/\/iiif.io\/api\/presentation\/3\/context.json"
+  ],
+  "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/696",
+  "type": "Manifest",
+  "label": {
+    "en": [
+      "Sketch of Gottfried Galston performing at a concert"
+    ]
+  },
+  "summary": {
+    "en": [
+      "This sketch depicts Galston before a concert performance on April 2, 1908. Inscribed is the text \"Avant le Concert le 2. Avril 08.\" In the background is a man with a mustache holding a money bag with the name \"Dandelot\" written above his head. This is likely Arthur Dandelot, a French music critic and and artist's agent."
+    ]
+  },
+  "metadata": [
+    {
+      "label": {
+        "en": [
+          "Date"
+        ]
+      },
+      "value": {
+        "en": [
+          "April 26, 1908",
+          "1908-04-26"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Format"
+        ]
+      },
+      "value": {
+        "en": [
+          "sketches"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Subject"
+        ]
+      },
+      "value": {
+        "en": [
+          "Piano",
+          "Concerts"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Description"
+        ]
+      },
+      "value": {
+        "en": [
+          "This sketch depicts Galston before a concert performance on April 2, 1908. Inscribed is the text \"Avant le Concert le 2. Avril 08.\" In the background is a man with a mustache holding a money bag with the name \"Dandelot\" written above his head. This is likely Arthur Dandelot, a French music critic and and artist's agent."
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Language"
+        ]
+      },
+      "value": {
+        "en": [
+          "French"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Photographer"
+        ]
+      },
+      "value": {
+        "en": [
+          "Bodmer, C. E."
+        ]
+      }
+    }
+  ],
+  "rights": "http:\/\/rightsstatements.org\/vocab\/UND\/1.0\/",
+  "requiredStatement": {
+    "label": {
+      "en": [
+        "Provided by"
+      ]
+    },
+    "value": {
+      "en": [
+        "University of Tennessee, Knoxville. Libraries"
+      ]
+    }
+  },
+  "provider": [
+    {
+      "id": "https:\/\/www.lib.utk.edu\/about\/",
+      "type": "Agent",
+      "label": {
+        "en": [
+          "University of Tennessee, Knoxville. Libraries"
+        ]
+      },
+      "homepage": [
+        {
+          "id": "https:\/\/www.lib.utk.edu\/",
+          "type": "Text",
+          "label": {
+            "en": [
+              "University of Tennessee Libraries Homepage"
+            ]
+          },
+          "format": "text\/html"
+        }
+      ],
+      "logo": [
+        {
+          "id": "https:\/\/utkdigitalinitiatives.github.io\/iiif-level-0\/ut_libraries_centered\/full\/full\/0\/default.jpg",
+          "type": "Image",
+          "format": "image\/jpeg",
+          "width": 200,
+          "height": 200
+        }
+      ]
+    }
+  ],
+  "thumbnail": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston%3A696~datastream~JP2\/full\/max\/0\/default.jpg",
+      "width": 7291,
+      "height": 3788,
+      "type": "Image",
+      "format": "image\/jpeg"
+    }
+  ],
+  "items": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/696\/canvas\/0",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Sketch of Gottfried Galston performing at a concert"
+        ]
+      },
+      "width": 7291,
+      "height": 3788,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/696\/canvas\/0\/page\/galston%3A696",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/696\/canvas\/0\/page\/galston%3A696\/623dc5cdae779",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston%3A696~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 7291,
+                  "height": 3788,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston%3A696~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/696\/canvas\/0"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "seeAlso": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/collections\/islandora\/object\/galston%3A696\/datastream\/MODS",
+      "type": "Dataset",
+      "label": {
+        "en": [
+          "Bibliographic Description in MODS"
+        ]
+      },
+      "format": "application\/xml",
+      "profile": "http:\/\/www.loc.gov\/standards\/mods\/v3\/mods-3-5.xsd"
+    }
+  ]
+}

--- a/iiif/galston_697.json
+++ b/iiif/galston_697.json
@@ -1,0 +1,189 @@
+{
+  "@context": [
+    "https:\/\/iiif.io\/api\/presentation\/3\/context.json"
+  ],
+  "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/697",
+  "type": "Manifest",
+  "label": {
+    "en": [
+      "Portrait of Gottfried Galston"
+    ]
+  },
+  "summary": {
+    "en": [
+      "Signed and dated monochromatic oil portrait of Gottfried Galston by Felix Meseck."
+    ]
+  },
+  "metadata": [
+    {
+      "label": {
+        "en": [
+          "Date"
+        ]
+      },
+      "value": {
+        "en": [
+          "1922",
+          "1922"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Format"
+        ]
+      },
+      "value": {
+        "en": [
+          "paintings (visual works)"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Subject"
+        ]
+      },
+      "value": {
+        "en": [
+          "Portraits",
+          "Musicians"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Description"
+        ]
+      },
+      "value": {
+        "en": [
+          "Signed and dated monochromatic oil portrait of Gottfried Galston by Felix Meseck."
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Artist"
+        ]
+      },
+      "value": {
+        "en": [
+          "Meseck, Felix, 1883-1955"
+        ]
+      }
+    }
+  ],
+  "rights": "http:\/\/rightsstatements.org\/vocab\/InC\/1.0\/",
+  "requiredStatement": {
+    "label": {
+      "en": [
+        "Provided by"
+      ]
+    },
+    "value": {
+      "en": [
+        "University of Tennessee, Knoxville. Libraries"
+      ]
+    }
+  },
+  "provider": [
+    {
+      "id": "https:\/\/www.lib.utk.edu\/about\/",
+      "type": "Agent",
+      "label": {
+        "en": [
+          "University of Tennessee, Knoxville. Libraries"
+        ]
+      },
+      "homepage": [
+        {
+          "id": "https:\/\/www.lib.utk.edu\/",
+          "type": "Text",
+          "label": {
+            "en": [
+              "University of Tennessee Libraries Homepage"
+            ]
+          },
+          "format": "text\/html"
+        }
+      ],
+      "logo": [
+        {
+          "id": "https:\/\/utkdigitalinitiatives.github.io\/iiif-level-0\/ut_libraries_centered\/full\/full\/0\/default.jpg",
+          "type": "Image",
+          "format": "image\/jpeg",
+          "width": 200,
+          "height": 200
+        }
+      ]
+    }
+  ],
+  "thumbnail": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston%3A697~datastream~JP2\/full\/max\/0\/default.jpg",
+      "width": 5386,
+      "height": 7590,
+      "type": "Image",
+      "format": "image\/jpeg"
+    }
+  ],
+  "items": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/697\/canvas\/0",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Portrait of Gottfried Galston"
+        ]
+      },
+      "width": 5386,
+      "height": 7590,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/697\/canvas\/0\/page\/galston%3A697",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/697\/canvas\/0\/page\/galston%3A697\/623dc5ceed4c8",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston%3A697~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 5386,
+                  "height": 7590,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston%3A697~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/697\/canvas\/0"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "seeAlso": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/collections\/islandora\/object\/galston%3A697\/datastream\/MODS",
+      "type": "Dataset",
+      "label": {
+        "en": [
+          "Bibliographic Description in MODS"
+        ]
+      },
+      "format": "application\/xml",
+      "profile": "http:\/\/www.loc.gov\/standards\/mods\/v3\/mods-3-5.xsd"
+    }
+  ]
+}

--- a/iiif/galston_697.json
+++ b/iiif/galston_697.json
@@ -2,7 +2,7 @@
   "@context": [
     "https:\/\/iiif.io\/api\/presentation\/3\/context.json"
   ],
-  "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/697",
+  "id": "https:\/\/digital.lib.utk.edu\/static\/iiif\/galston_697.json",
   "type": "Manifest",
   "label": {
     "en": [

--- a/iiif/galston_700.json
+++ b/iiif/galston_700.json
@@ -2,7 +2,7 @@
   "@context": [
     "https:\/\/iiif.io\/api\/presentation\/3\/context.json"
   ],
-  "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/700",
+  "id": "https:\/\/digital.lib.utk.edu\/static\/iiif\/galston_700.json",
   "type": "Manifest",
   "label": {
     "en": [

--- a/iiif/galston_700.json
+++ b/iiif/galston_700.json
@@ -1,0 +1,190 @@
+{
+  "@context": [
+    "https:\/\/iiif.io\/api\/presentation\/3\/context.json"
+  ],
+  "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/700",
+  "type": "Manifest",
+  "label": {
+    "en": [
+      "Lithograph made for posters for Gottfried Galston's Paris concerts"
+    ]
+  },
+  "summary": {
+    "en": [
+      "Original lithograph mounted on a board. The work depicts Gottfried Galston seated at a piano with ethereal figures participating in bebauchery emanating from the instrument. The figures include three mounted horsemen, a winged angel, and a crucified man."
+    ]
+  },
+  "metadata": [
+    {
+      "label": {
+        "en": [
+          "Date"
+        ]
+      },
+      "value": {
+        "en": [
+          "1911",
+          "1911"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Format"
+        ]
+      },
+      "value": {
+        "en": [
+          "lithographs"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Subject"
+        ]
+      },
+      "value": {
+        "en": [
+          "Concerts",
+          "Musicians",
+          "Piano"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Description"
+        ]
+      },
+      "value": {
+        "en": [
+          "Original lithograph mounted on a board. The work depicts Gottfried Galston seated at a piano with ethereal figures participating in bebauchery emanating from the instrument. The figures include three mounted horsemen, a winged angel, and a crucified man."
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Artist"
+        ]
+      },
+      "value": {
+        "en": [
+          "Veber, Jean, 1864-1928"
+        ]
+      }
+    }
+  ],
+  "rights": "http:\/\/rightsstatements.org\/vocab\/NKC\/1.0\/",
+  "requiredStatement": {
+    "label": {
+      "en": [
+        "Provided by"
+      ]
+    },
+    "value": {
+      "en": [
+        "University of Tennessee, Knoxville. Libraries"
+      ]
+    }
+  },
+  "provider": [
+    {
+      "id": "https:\/\/www.lib.utk.edu\/about\/",
+      "type": "Agent",
+      "label": {
+        "en": [
+          "University of Tennessee, Knoxville. Libraries"
+        ]
+      },
+      "homepage": [
+        {
+          "id": "https:\/\/www.lib.utk.edu\/",
+          "type": "Text",
+          "label": {
+            "en": [
+              "University of Tennessee Libraries Homepage"
+            ]
+          },
+          "format": "text\/html"
+        }
+      ],
+      "logo": [
+        {
+          "id": "https:\/\/utkdigitalinitiatives.github.io\/iiif-level-0\/ut_libraries_centered\/full\/full\/0\/default.jpg",
+          "type": "Image",
+          "format": "image\/jpeg",
+          "width": 200,
+          "height": 200
+        }
+      ]
+    }
+  ],
+  "thumbnail": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston%3A700~datastream~JP2\/full\/max\/0\/default.jpg",
+      "width": 6941,
+      "height": 5901,
+      "type": "Image",
+      "format": "image\/jpeg"
+    }
+  ],
+  "items": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/700\/canvas\/0",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Lithograph made for posters for Gottfried Galston's Paris concerts"
+        ]
+      },
+      "width": 6941,
+      "height": 5901,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/700\/canvas\/0\/page\/galston%3A700",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/700\/canvas\/0\/page\/galston%3A700\/623dc5d283d6a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston%3A700~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6941,
+                  "height": 5901,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston%3A700~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/700\/canvas\/0"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "seeAlso": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/collections\/islandora\/object\/galston%3A700\/datastream\/MODS",
+      "type": "Dataset",
+      "label": {
+        "en": [
+          "Bibliographic Description in MODS"
+        ]
+      },
+      "format": "application\/xml",
+      "profile": "http:\/\/www.loc.gov\/standards\/mods\/v3\/mods-3-5.xsd"
+    }
+  ]
+}

--- a/iiif/galston_701.json
+++ b/iiif/galston_701.json
@@ -1,0 +1,202 @@
+{
+  "@context": [
+    "https:\/\/iiif.io\/api\/presentation\/3\/context.json"
+  ],
+  "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/701",
+  "type": "Manifest",
+  "label": {
+    "en": [
+      "Sketch of Gottfried Galston at the piano"
+    ]
+  },
+  "summary": {
+    "en": [
+      "Sketch depicting Galston at the piano with female figures wearing hats roughly rendered in the background. The work includes the inscription \"\u00e0 Gottfried Galston, avec toute[s] mes excuses.\" This note from the artist Veber apologizes to Galston in case the caricature is seen as unflattering."
+    ]
+  },
+  "metadata": [
+    {
+      "label": {
+        "en": [
+          "Date"
+        ]
+      },
+      "value": {
+        "en": [
+          "1909",
+          "1909"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Format"
+        ]
+      },
+      "value": {
+        "en": [
+          "sketches"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Subject"
+        ]
+      },
+      "value": {
+        "en": [
+          "Concerts",
+          "Musicians",
+          "Piano"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Description"
+        ]
+      },
+      "value": {
+        "en": [
+          "Sketch depicting Galston at the piano with female figures wearing hats roughly rendered in the background. The work includes the inscription \"\u00e0 Gottfried Galston, avec toute[s] mes excuses.\" This note from the artist Veber apologizes to Galston in case the caricature is seen as unflattering."
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Language"
+        ]
+      },
+      "value": {
+        "en": [
+          "French"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Artist"
+        ]
+      },
+      "value": {
+        "en": [
+          "Veber, Jean, 1864-1928"
+        ]
+      }
+    }
+  ],
+  "rights": "http:\/\/rightsstatements.org\/vocab\/NKC\/1.0\/",
+  "requiredStatement": {
+    "label": {
+      "en": [
+        "Provided by"
+      ]
+    },
+    "value": {
+      "en": [
+        "University of Tennessee, Knoxville. Libraries"
+      ]
+    }
+  },
+  "provider": [
+    {
+      "id": "https:\/\/www.lib.utk.edu\/about\/",
+      "type": "Agent",
+      "label": {
+        "en": [
+          "University of Tennessee, Knoxville. Libraries"
+        ]
+      },
+      "homepage": [
+        {
+          "id": "https:\/\/www.lib.utk.edu\/",
+          "type": "Text",
+          "label": {
+            "en": [
+              "University of Tennessee Libraries Homepage"
+            ]
+          },
+          "format": "text\/html"
+        }
+      ],
+      "logo": [
+        {
+          "id": "https:\/\/utkdigitalinitiatives.github.io\/iiif-level-0\/ut_libraries_centered\/full\/full\/0\/default.jpg",
+          "type": "Image",
+          "format": "image\/jpeg",
+          "width": 200,
+          "height": 200
+        }
+      ]
+    }
+  ],
+  "thumbnail": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston%3A701~datastream~JP2\/full\/max\/0\/default.jpg",
+      "width": 7719,
+      "height": 5835,
+      "type": "Image",
+      "format": "image\/jpeg"
+    }
+  ],
+  "items": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/701\/canvas\/0",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Sketch of Gottfried Galston at the piano"
+        ]
+      },
+      "width": 7719,
+      "height": 5835,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/701\/canvas\/0\/page\/galston%3A701",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/701\/canvas\/0\/page\/galston%3A701\/623dc5d3e833d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston%3A701~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 7719,
+                  "height": 5835,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston%3A701~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/701\/canvas\/0"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "seeAlso": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/collections\/islandora\/object\/galston%3A701\/datastream\/MODS",
+      "type": "Dataset",
+      "label": {
+        "en": [
+          "Bibliographic Description in MODS"
+        ]
+      },
+      "format": "application\/xml",
+      "profile": "http:\/\/www.loc.gov\/standards\/mods\/v3\/mods-3-5.xsd"
+    }
+  ]
+}

--- a/iiif/galston_701.json
+++ b/iiif/galston_701.json
@@ -2,7 +2,7 @@
   "@context": [
     "https:\/\/iiif.io\/api\/presentation\/3\/context.json"
   ],
-  "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/701",
+  "id": "https:\/\/digital.lib.utk.edu\/static\/iiif\/galston_701.json",
   "type": "Manifest",
   "label": {
     "en": [

--- a/iiif/galston_703.json
+++ b/iiif/galston_703.json
@@ -2,7 +2,7 @@
   "@context": [
     "https://iiif.io/api/presentation/3/context.json"
   ],
-  "id": "https://digital.lib.utk.edu/assemble/manifest/galston/703",
+  "id": "https:\/\/digital.lib.utk.edu\/static\/iiif\/galston_703.json",
   "type": "Manifest",
   "label": {
     "en": [

--- a/iiif/galston_706.json
+++ b/iiif/galston_706.json
@@ -2,7 +2,7 @@
   "@context": [
     "https:\/\/iiif.io\/api\/presentation\/3\/context.json"
   ],
-  "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/706",
+  "id": "https:\/\/digital.lib.utk.edu\/static\/iiif\/galston_706.json",
   "type": "Manifest",
   "label": {
     "en": [

--- a/iiif/galston_706.json
+++ b/iiif/galston_706.json
@@ -1,0 +1,215 @@
+{
+  "@context": [
+    "https:\/\/iiif.io\/api\/presentation\/3\/context.json"
+  ],
+  "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/706",
+  "type": "Manifest",
+  "label": {
+    "en": [
+      "Studio portrait of Sandra Droucker by Eduard Wasow"
+    ]
+  },
+  "summary": {
+    "en": [
+      "Photograph of Sandra Droucker, a pianist and Galston's first wife. Galston and Droucker married in 1910 and divorced in 1918. A handwritten note on this photograph dates it to approximately 1918."
+    ]
+  },
+  "metadata": [
+    {
+      "label": {
+        "en": [
+          "Date"
+        ]
+      },
+      "value": {
+        "en": [
+          "circa 1918",
+          "circa 1918"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Format"
+        ]
+      },
+      "value": {
+        "en": [
+          "photographs"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Subject"
+        ]
+      },
+      "value": {
+        "en": [
+          "Portraits",
+          "Musicians",
+          "Women musicians",
+          "Wives"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Place"
+        ]
+      },
+      "value": {
+        "en": [
+          "Munich"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Description"
+        ]
+      },
+      "value": {
+        "en": [
+          "Photograph of Sandra Droucker, a pianist and Galston's first wife. Galston and Droucker married in 1910 and divorced in 1918. A handwritten note on this photograph dates it to approximately 1918."
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Language"
+        ]
+      },
+      "value": {
+        "en": [
+          "English"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Photographer"
+        ]
+      },
+      "value": {
+        "en": [
+          "Wasow, Eduard"
+        ]
+      }
+    }
+  ],
+  "rights": "http:\/\/rightsstatements.org\/vocab\/NKC\/1.0\/",
+  "requiredStatement": {
+    "label": {
+      "en": [
+        "Provided by"
+      ]
+    },
+    "value": {
+      "en": [
+        "University of Tennessee, Knoxville. Libraries"
+      ]
+    }
+  },
+  "provider": [
+    {
+      "id": "https:\/\/www.lib.utk.edu\/about\/",
+      "type": "Agent",
+      "label": {
+        "en": [
+          "University of Tennessee, Knoxville. Libraries"
+        ]
+      },
+      "homepage": [
+        {
+          "id": "https:\/\/www.lib.utk.edu\/",
+          "type": "Text",
+          "label": {
+            "en": [
+              "University of Tennessee Libraries Homepage"
+            ]
+          },
+          "format": "text\/html"
+        }
+      ],
+      "logo": [
+        {
+          "id": "https:\/\/utkdigitalinitiatives.github.io\/iiif-level-0\/ut_libraries_centered\/full\/full\/0\/default.jpg",
+          "type": "Image",
+          "format": "image\/jpeg",
+          "width": 200,
+          "height": 200
+        }
+      ]
+    }
+  ],
+  "thumbnail": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston%3A706~datastream~JP2\/full\/max\/0\/default.jpg",
+      "width": 6018,
+      "height": 7983,
+      "type": "Image",
+      "format": "image\/jpeg"
+    }
+  ],
+  "items": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/706\/canvas\/0",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studio portrait of Sandra Droucker by Eduard Wasow"
+        ]
+      },
+      "width": 6018,
+      "height": 7983,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/706\/canvas\/0\/page\/galston%3A706",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/706\/canvas\/0\/page\/galston%3A706\/623dc5d9edc90",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston%3A706~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6018,
+                  "height": 7983,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston%3A706~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/706\/canvas\/0"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "seeAlso": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/collections\/islandora\/object\/galston%3A706\/datastream\/MODS",
+      "type": "Dataset",
+      "label": {
+        "en": [
+          "Bibliographic Description in MODS"
+        ]
+      },
+      "format": "application\/xml",
+      "profile": "http:\/\/www.loc.gov\/standards\/mods\/v3\/mods-3-5.xsd"
+    }
+  ]
+}

--- a/iiif/galston_710.json
+++ b/iiif/galston_710.json
@@ -2,7 +2,7 @@
   "@context": [
     "https:\/\/iiif.io\/api\/presentation\/3\/context.json"
   ],
-  "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/710",
+  "id": "https:\/\/digital.lib.utk.edu\/static\/iiif\/galston_710.json",
   "type": "Manifest",
   "label": {
     "en": [

--- a/iiif/galston_710.json
+++ b/iiif/galston_710.json
@@ -1,0 +1,215 @@
+{
+  "@context": [
+    "https:\/\/iiif.io\/api\/presentation\/3\/context.json"
+  ],
+  "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/710",
+  "type": "Manifest",
+  "label": {
+    "en": [
+      "Photograph of Gottfried Galston at piano"
+    ]
+  },
+  "summary": {
+    "en": [
+      "Photograph taken of Galston at approximately age 23 by Elliot & Fry. The date is handwritten on the reverse, \"ca. 1902\", which coincides with concert tours given by Galston in London."
+    ]
+  },
+  "metadata": [
+    {
+      "label": {
+        "en": [
+          "Date"
+        ]
+      },
+      "value": {
+        "en": [
+          "circa 1902",
+          "",
+          "1902"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Format"
+        ]
+      },
+      "value": {
+        "en": [
+          "photographs"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Subject"
+        ]
+      },
+      "value": {
+        "en": [
+          "Portraits",
+          "Musicians",
+          "Piano"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Place"
+        ]
+      },
+      "value": {
+        "en": [
+          "London"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Description"
+        ]
+      },
+      "value": {
+        "en": [
+          "Photograph taken of Galston at approximately age 23 by Elliot & Fry. The date is handwritten on the reverse, \"ca. 1902\", which coincides with concert tours given by Galston in London."
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Language"
+        ]
+      },
+      "value": {
+        "en": [
+          "No linguistic content"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Photographer"
+        ]
+      },
+      "value": {
+        "en": [
+          "Elliott & Fry"
+        ]
+      }
+    }
+  ],
+  "rights": "http:\/\/rightsstatements.org\/vocab\/NKC\/1.0\/",
+  "requiredStatement": {
+    "label": {
+      "en": [
+        "Provided by"
+      ]
+    },
+    "value": {
+      "en": [
+        "University of Tennessee, Knoxville. Libraries"
+      ]
+    }
+  },
+  "provider": [
+    {
+      "id": "https:\/\/www.lib.utk.edu\/about\/",
+      "type": "Agent",
+      "label": {
+        "en": [
+          "University of Tennessee, Knoxville. Libraries"
+        ]
+      },
+      "homepage": [
+        {
+          "id": "https:\/\/www.lib.utk.edu\/",
+          "type": "Text",
+          "label": {
+            "en": [
+              "University of Tennessee Libraries Homepage"
+            ]
+          },
+          "format": "text\/html"
+        }
+      ],
+      "logo": [
+        {
+          "id": "https:\/\/utkdigitalinitiatives.github.io\/iiif-level-0\/ut_libraries_centered\/full\/full\/0\/default.jpg",
+          "type": "Image",
+          "format": "image\/jpeg",
+          "width": 200,
+          "height": 200
+        }
+      ]
+    }
+  ],
+  "thumbnail": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston%3A710~datastream~JP2\/full\/max\/0\/default.jpg",
+      "width": 5941,
+      "height": 7014,
+      "type": "Image",
+      "format": "image\/jpeg"
+    }
+  ],
+  "items": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/710\/canvas\/0",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Photograph of Gottfried Galston at piano"
+        ]
+      },
+      "width": 5941,
+      "height": 7014,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/710\/canvas\/0\/page\/galston%3A710",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/710\/canvas\/0\/page\/galston%3A710\/623dc5dedb3b4",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston%3A710~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 5941,
+                  "height": 7014,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston%3A710~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/710\/canvas\/0"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "seeAlso": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/collections\/islandora\/object\/galston%3A710\/datastream\/MODS",
+      "type": "Dataset",
+      "label": {
+        "en": [
+          "Bibliographic Description in MODS"
+        ]
+      },
+      "format": "application\/xml",
+      "profile": "http:\/\/www.loc.gov\/standards\/mods\/v3\/mods-3-5.xsd"
+    }
+  ]
+}

--- a/iiif/galston_716.json
+++ b/iiif/galston_716.json
@@ -1,0 +1,192 @@
+{
+  "@context": [
+    "https:\/\/iiif.io\/api\/presentation\/3\/context.json"
+  ],
+  "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/716",
+  "type": "Manifest",
+  "label": {
+    "en": [
+      "Photograph of Gerda Busoni, Gottfried Galston, Ferruccio Busoni, and Sandra Droucker Galston"
+    ]
+  },
+  "summary": {
+    "en": [
+      "Photograph of Gerda Busoni, Gottfried Galston, Ferruccio Busoni, and Sandra Droucker Galston. Sandra holds a dog in her lap and wine bottles are on the table."
+    ]
+  },
+  "metadata": [
+    {
+      "label": {
+        "en": [
+          "Date"
+        ]
+      },
+      "value": {
+        "en": [
+          "1905-1918",
+          "1905",
+          "1918"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Format"
+        ]
+      },
+      "value": {
+        "en": [
+          "photographs"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Subject"
+        ]
+      },
+      "value": {
+        "en": [
+          "Entertaining",
+          "Portraits, Group",
+          "Musicians",
+          "Wives"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Description"
+        ]
+      },
+      "value": {
+        "en": [
+          "Photograph of Gerda Busoni, Gottfried Galston, Ferruccio Busoni, and Sandra Droucker Galston. Sandra holds a dog in her lap and wine bottles are on the table."
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Language"
+        ]
+      },
+      "value": {
+        "en": [
+          "No linguistic content"
+        ]
+      }
+    }
+  ],
+  "rights": "http:\/\/rightsstatements.org\/vocab\/UND\/1.0\/",
+  "requiredStatement": {
+    "label": {
+      "en": [
+        "Provided by"
+      ]
+    },
+    "value": {
+      "en": [
+        "University of Tennessee, Knoxville. Libraries"
+      ]
+    }
+  },
+  "provider": [
+    {
+      "id": "https:\/\/www.lib.utk.edu\/about\/",
+      "type": "Agent",
+      "label": {
+        "en": [
+          "University of Tennessee, Knoxville. Libraries"
+        ]
+      },
+      "homepage": [
+        {
+          "id": "https:\/\/www.lib.utk.edu\/",
+          "type": "Text",
+          "label": {
+            "en": [
+              "University of Tennessee Libraries Homepage"
+            ]
+          },
+          "format": "text\/html"
+        }
+      ],
+      "logo": [
+        {
+          "id": "https:\/\/utkdigitalinitiatives.github.io\/iiif-level-0\/ut_libraries_centered\/full\/full\/0\/default.jpg",
+          "type": "Image",
+          "format": "image\/jpeg",
+          "width": 200,
+          "height": 200
+        }
+      ]
+    }
+  ],
+  "thumbnail": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston%3A716~datastream~JP2\/full\/max\/0\/default.jpg",
+      "width": 4185,
+      "height": 5497,
+      "type": "Image",
+      "format": "image\/jpeg"
+    }
+  ],
+  "items": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/716\/canvas\/0",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Photograph of Gerda Busoni, Gottfried Galston, Ferruccio Busoni, and Sandra Droucker Galston"
+        ]
+      },
+      "width": 4185,
+      "height": 5497,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/716\/canvas\/0\/page\/galston%3A716",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/716\/canvas\/0\/page\/galston%3A716\/623dc5e1ca156",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston%3A716~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 4185,
+                  "height": 5497,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston%3A716~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/716\/canvas\/0"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "seeAlso": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/collections\/islandora\/object\/galston%3A716\/datastream\/MODS",
+      "type": "Dataset",
+      "label": {
+        "en": [
+          "Bibliographic Description in MODS"
+        ]
+      },
+      "format": "application\/xml",
+      "profile": "http:\/\/www.loc.gov\/standards\/mods\/v3\/mods-3-5.xsd"
+    }
+  ]
+}

--- a/iiif/galston_716.json
+++ b/iiif/galston_716.json
@@ -2,7 +2,7 @@
   "@context": [
     "https:\/\/iiif.io\/api\/presentation\/3\/context.json"
   ],
-  "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/716",
+  "id": "https:\/\/digital.lib.utk.edu\/static\/iiif\/galston_716.json",
   "type": "Manifest",
   "label": {
     "en": [

--- a/iiif/galston_718.json
+++ b/iiif/galston_718.json
@@ -2,7 +2,7 @@
   "@context": [
     "https:\/\/iiif.io\/api\/presentation\/3\/context.json"
   ],
-  "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/718",
+  "id": "https:\/\/digital.lib.utk.edu\/static\/iiif\/galston_718.json",
   "type": "Manifest",
   "label": {
     "en": [

--- a/iiif/galston_718.json
+++ b/iiif/galston_718.json
@@ -1,0 +1,214 @@
+{
+  "@context": [
+    "https:\/\/iiif.io\/api\/presentation\/3\/context.json"
+  ],
+  "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/718",
+  "type": "Manifest",
+  "label": {
+    "en": [
+      "Plaster casts of Ferruccio Busoni's and Gottfried Galston's right hands"
+    ]
+  },
+  "summary": {
+    "en": [
+      "Busoni's hand is on the left and Galston's hand is on the right. Both are laid on top of sheet music."
+    ]
+  },
+  "metadata": [
+    {
+      "label": {
+        "en": [
+          "Date"
+        ]
+      },
+      "value": {
+        "en": [
+          "2019",
+          "2019"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Format"
+        ]
+      },
+      "value": {
+        "en": [
+          "photographs",
+          "casts (sculpture)"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Subject"
+        ]
+      },
+      "value": {
+        "en": [
+          "Plaster casts",
+          "Musicians"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Description"
+        ]
+      },
+      "value": {
+        "en": [
+          "Busoni's hand is on the left and Galston's hand is on the right. Both are laid on top of sheet music."
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Language"
+        ]
+      },
+      "value": {
+        "en": [
+          "No linguistic content"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Photographer"
+        ]
+      },
+      "value": {
+        "en": [
+          "O'Barr, Shelley"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Restorationist"
+        ]
+      },
+      "value": {
+        "en": [
+          "Wingerd, Harriet Ungals"
+        ]
+      }
+    }
+  ],
+  "rights": "http:\/\/rightsstatements.org\/vocab\/InC\/1.0\/",
+  "requiredStatement": {
+    "label": {
+      "en": [
+        "Provided by"
+      ]
+    },
+    "value": {
+      "en": [
+        "University of Tennessee, Knoxville. Libraries"
+      ]
+    }
+  },
+  "provider": [
+    {
+      "id": "https:\/\/www.lib.utk.edu\/about\/",
+      "type": "Agent",
+      "label": {
+        "en": [
+          "University of Tennessee, Knoxville. Libraries"
+        ]
+      },
+      "homepage": [
+        {
+          "id": "https:\/\/www.lib.utk.edu\/",
+          "type": "Text",
+          "label": {
+            "en": [
+              "University of Tennessee Libraries Homepage"
+            ]
+          },
+          "format": "text\/html"
+        }
+      ],
+      "logo": [
+        {
+          "id": "https:\/\/utkdigitalinitiatives.github.io\/iiif-level-0\/ut_libraries_centered\/full\/full\/0\/default.jpg",
+          "type": "Image",
+          "format": "image\/jpeg",
+          "width": 200,
+          "height": 200
+        }
+      ]
+    }
+  ],
+  "thumbnail": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston%3A718~datastream~JP2\/full\/max\/0\/default.jpg",
+      "width": 6000,
+      "height": 4000,
+      "type": "Image",
+      "format": "image\/jpeg"
+    }
+  ],
+  "items": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/718\/canvas\/0",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Plaster casts of Ferruccio Busoni's and Gottfried Galston's right hands"
+        ]
+      },
+      "width": 6000,
+      "height": 4000,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/718\/canvas\/0\/page\/galston%3A718",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/718\/canvas\/0\/page\/galston%3A718\/623dc5e41c62e",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston%3A718~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 6000,
+                  "height": 4000,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston%3A718~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/718\/canvas\/0"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "seeAlso": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/collections\/islandora\/object\/galston%3A718\/datastream\/MODS",
+      "type": "Dataset",
+      "label": {
+        "en": [
+          "Bibliographic Description in MODS"
+        ]
+      },
+      "format": "application\/xml",
+      "profile": "http:\/\/www.loc.gov\/standards\/mods\/v3\/mods-3-5.xsd"
+    }
+  ]
+}

--- a/iiif/galston_736.json
+++ b/iiif/galston_736.json
@@ -1,0 +1,8418 @@
+{
+  "@context": [
+    "https:\/\/iiif.io\/api\/presentation\/3\/context.json"
+  ],
+  "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736",
+  "type": "Manifest",
+  "label": {
+    "en": [
+      "Studienbuch"
+    ]
+  },
+  "summary": {
+    "en": [
+      "Detailed commentary on the performance of selected piano works by Bach, Beethoven, Chopin, Liszt and Brahms."
+    ]
+  },
+  "metadata": [
+    {
+      "label": {
+        "en": [
+          "Publication Date"
+        ]
+      },
+      "value": {
+        "en": [
+          "2009",
+          "2009"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Format"
+        ]
+      },
+      "value": {
+        "en": [
+          "books"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Extent"
+        ]
+      },
+      "value": {
+        "en": [
+          "211 pages"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Subject"
+        ]
+      },
+      "value": {
+        "en": [
+          "Music",
+          "Piano music"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Description"
+        ]
+      },
+      "value": {
+        "en": [
+          "Detailed commentary on the performance of selected piano works by Bach, Beethoven, Chopin, Liszt and Brahms."
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Language"
+        ]
+      },
+      "value": {
+        "en": [
+          "English"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Author"
+        ]
+      },
+      "value": {
+        "en": [
+          "Galston, Gottfried, 1879-1950"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Translator"
+        ]
+      },
+      "value": {
+        "en": [
+          "Greenman, Rosemarie S."
+        ]
+      }
+    }
+  ],
+  "rights": "http:\/\/rightsstatements.org\/vocab\/InC\/1.0\/",
+  "requiredStatement": {
+    "label": {
+      "en": [
+        "Provided by"
+      ]
+    },
+    "value": {
+      "en": [
+        "University of Tennessee, Knoxville. Libraries"
+      ]
+    }
+  },
+  "provider": [
+    {
+      "id": "https:\/\/www.lib.utk.edu\/about\/",
+      "type": "Agent",
+      "label": {
+        "en": [
+          "University of Tennessee, Knoxville. Libraries"
+        ]
+      },
+      "homepage": [
+        {
+          "id": "https:\/\/www.lib.utk.edu\/",
+          "type": "Text",
+          "label": {
+            "en": [
+              "University of Tennessee Libraries Homepage"
+            ]
+          },
+          "format": "text\/html"
+        }
+      ],
+      "logo": [
+        {
+          "id": "https:\/\/utkdigitalinitiatives.github.io\/iiif-level-0\/ut_libraries_centered\/full\/full\/0\/default.jpg",
+          "type": "Image",
+          "format": "image\/jpeg",
+          "width": 200,
+          "height": 200
+        }
+      ]
+    }
+  ],
+  "thumbnail": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/collections\/islandora\/object\/galston%3A736\/datastream\/JP2",
+      "width": 200,
+      "height": 200,
+      "type": "Image",
+      "format": "image\/jpeg"
+    }
+  ],
+  "items": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/0",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 1"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/0\/page\/galston:737",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/0\/page\/galston:737\/623dc660cc75e",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:737~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:737~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/0"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/1",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 2"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/1\/page\/galston:947",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/1\/page\/galston:947\/623dc661b2ce5",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:947~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:947~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/1"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/2",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 3"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/2\/page\/galston:946",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/2\/page\/galston:946\/623dc66293f12",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:946~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:946~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/2"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/3",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 4"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/3\/page\/galston:945",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/3\/page\/galston:945\/623dc6637526c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:945~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:945~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/4",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 5"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/4\/page\/galston:944",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/4\/page\/galston:944\/623dc66450896",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:944~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:944~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/4"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/5",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 6"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/5\/page\/galston:943",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/5\/page\/galston:943\/623dc66541a00",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:943~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:943~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/5"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/6",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 7"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/6\/page\/galston:942",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/6\/page\/galston:942\/623dc6662c1bf",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:942~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:942~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/6"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/7",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 8"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/7\/page\/galston:941",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/7\/page\/galston:941\/623dc6671d690",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:941~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:941~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/7"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/8",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 9"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/8\/page\/galston:940",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/8\/page\/galston:940\/623dc6680ba8d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:940~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:940~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/8"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/9",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 10"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/9\/page\/galston:939",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/9\/page\/galston:939\/623dc668efc0f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:939~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:939~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/9"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/10",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 11"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/10\/page\/galston:938",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/10\/page\/galston:938\/623dc669de9fe",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:938~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:938~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/10"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/11",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 12"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/11\/page\/galston:937",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/11\/page\/galston:937\/623dc66acd7d0",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:937~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:937~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/11"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/12",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 13"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/12\/page\/galston:936",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/12\/page\/galston:936\/623dc66bbd6c3",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:936~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:936~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/12"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/13",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 14"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/13\/page\/galston:935",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/13\/page\/galston:935\/623dc66cadc67",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:935~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:935~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/13"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/14",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 15"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/14\/page\/galston:934",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/14\/page\/galston:934\/623dc66d9c8a0",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:934~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:934~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/14"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/15",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 16"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/15\/page\/galston:933",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/15\/page\/galston:933\/623dc66e8baf4",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:933~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:933~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/15"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/16",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 17"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/16\/page\/galston:932",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/16\/page\/galston:932\/623dc66f77dc5",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:932~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:932~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/16"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/17",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 18"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/17\/page\/galston:931",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/17\/page\/galston:931\/623dc67066081",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:931~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:931~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/17"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/18",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 19"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/18\/page\/galston:930",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/18\/page\/galston:930\/623dc67153f8a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:930~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:930~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/18"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/19",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 20"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/19\/page\/galston:929",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/19\/page\/galston:929\/623dc67242e08",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:929~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:929~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/19"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/20",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 21"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/20\/page\/galston:928",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/20\/page\/galston:928\/623dc6731dfa6",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:928~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:928~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/20"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/21",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 22"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/21\/page\/galston:927",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/21\/page\/galston:927\/623dc67407038",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:927~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:927~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/21"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/22",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 23"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/22\/page\/galston:926",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/22\/page\/galston:926\/623dc674e89a4",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:926~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:926~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/22"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/23",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 24"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/23\/page\/galston:925",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/23\/page\/galston:925\/623dc675dc60b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:925~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:925~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/23"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/24",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 25"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/24\/page\/galston:924",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/24\/page\/galston:924\/623dc676c763f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:924~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:924~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/24"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/25",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 26"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/25\/page\/galston:923",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/25\/page\/galston:923\/623dc677b39c9",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:923~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:923~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/25"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/26",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 27"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/26\/page\/galston:922",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/26\/page\/galston:922\/623dc678a1167",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:922~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:922~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/26"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/27",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 28"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/27\/page\/galston:921",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/27\/page\/galston:921\/623dc6798d225",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:921~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:921~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/27"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/28",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 29"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/28\/page\/galston:920",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/28\/page\/galston:920\/623dc67a7cbe0",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:920~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:920~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/28"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/29",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 30"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/29\/page\/galston:919",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/29\/page\/galston:919\/623dc67b6a369",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:919~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:919~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/29"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/30",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 31"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/30\/page\/galston:918",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/30\/page\/galston:918\/623dc67c58a90",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:918~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:918~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/30"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/31",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 32"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/31\/page\/galston:917",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/31\/page\/galston:917\/623dc67d48015",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:917~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:917~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/31"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/32",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 33"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/32\/page\/galston:916",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/32\/page\/galston:916\/623dc67e2a82b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:916~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:916~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/32"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/33",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 34"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/33\/page\/galston:915",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/33\/page\/galston:915\/623dc67f09f8b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:915~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:915~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/33"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/34",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 35"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/34\/page\/galston:914",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/34\/page\/galston:914\/623dc67fee487",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:914~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:914~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/34"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/35",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 36"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/35\/page\/galston:913",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/35\/page\/galston:913\/623dc680e01ab",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:913~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:913~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/35"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/36",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 37"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/36\/page\/galston:912",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/36\/page\/galston:912\/623dc681c72ee",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:912~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:912~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/36"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/37",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 38"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/37\/page\/galston:911",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/37\/page\/galston:911\/623dc682b7166",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:911~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:911~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/37"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/38",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 39"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/38\/page\/galston:910",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/38\/page\/galston:910\/623dc683a96e7",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:910~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:910~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/38"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/39",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 40"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/39\/page\/galston:909",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/39\/page\/galston:909\/623dc6849b04c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:909~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:909~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/39"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/40",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 41"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/40\/page\/galston:908",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/40\/page\/galston:908\/623dc685886bd",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:908~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:908~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/40"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/41",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 42"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/41\/page\/galston:907",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/41\/page\/galston:907\/623dc6867bc09",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:907~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:907~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/41"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/42",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 43"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/42\/page\/galston:906",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/42\/page\/galston:906\/623dc6876ce6c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:906~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:906~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/42"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/43",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 44"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/43\/page\/galston:905",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/43\/page\/galston:905\/623dc68860a49",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:905~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:905~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/43"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/44",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 45"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/44\/page\/galston:904",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/44\/page\/galston:904\/623dc6894aeef",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:904~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:904~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/44"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/45",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 46"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/45\/page\/galston:903",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/45\/page\/galston:903\/623dc68a300ac",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:903~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:903~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/45"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/46",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 47"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/46\/page\/galston:902",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/46\/page\/galston:902\/623dc68b29f8e",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:902~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:902~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/46"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/47",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 48"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/47\/page\/galston:901",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/47\/page\/galston:901\/623dc68c18dea",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:901~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:901~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/47"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/48",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 49"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/48\/page\/galston:900",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/48\/page\/galston:900\/623dc68d0d213",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:900~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:900~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/48"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/49",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 50"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/49\/page\/galston:899",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/49\/page\/galston:899\/623dc68deb116",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:899~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:899~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/49"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/50",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 51"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/50\/page\/galston:898",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/50\/page\/galston:898\/623dc68ed7481",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:898~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:898~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/50"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/51",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 52"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/51\/page\/galston:897",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/51\/page\/galston:897\/623dc68fc1072",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:897~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:897~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/51"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/52",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 53"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/52\/page\/galston:896",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/52\/page\/galston:896\/623dc690aefdd",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:896~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:896~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/52"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/53",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 54"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/53\/page\/galston:895",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/53\/page\/galston:895\/623dc6919ee01",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:895~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:895~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/53"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/54",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 55"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/54\/page\/galston:894",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/54\/page\/galston:894\/623dc6928da17",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:894~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:894~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/54"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/55",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 56"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/55\/page\/galston:893",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/55\/page\/galston:893\/623dc6938482a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:893~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:893~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/55"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/56",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 57"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/56\/page\/galston:892",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/56\/page\/galston:892\/623dc69475207",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:892~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:892~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/56"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/57",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 58"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/57\/page\/galston:891",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/57\/page\/galston:891\/623dc695634b6",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:891~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:891~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/57"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/58",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 59"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/58\/page\/galston:890",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/58\/page\/galston:890\/623dc69658564",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:890~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:890~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/58"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/59",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 60"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/59\/page\/galston:889",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/59\/page\/galston:889\/623dc69748f4b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:889~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:889~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/59"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/60",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 61"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/60\/page\/galston:888",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/60\/page\/galston:888\/623dc69834abd",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:888~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:888~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/60"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/61",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 62"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/61\/page\/galston:887",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/61\/page\/galston:887\/623dc6992b2e0",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:887~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:887~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/61"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/62",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 63"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/62\/page\/galston:886",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/62\/page\/galston:886\/623dc69a17e0c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:886~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:886~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/62"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/63",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 64"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/63\/page\/galston:885",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/63\/page\/galston:885\/623dc69b0610a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:885~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:885~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/63"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/64",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 65"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/64\/page\/galston:884",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/64\/page\/galston:884\/623dc69be94b0",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:884~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:884~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/64"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/65",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 66"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/65\/page\/galston:883",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/65\/page\/galston:883\/623dc69cd890d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:883~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:883~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/65"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/66",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 67"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/66\/page\/galston:882",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/66\/page\/galston:882\/623dc69dc3486",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:882~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:882~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/66"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/67",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 68"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/67\/page\/galston:881",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/67\/page\/galston:881\/623dc69ea7771",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:881~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:881~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/67"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/68",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 69"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/68\/page\/galston:880",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/68\/page\/galston:880\/623dc69f8c2f9",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:880~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:880~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/68"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/69",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 70"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/69\/page\/galston:879",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/69\/page\/galston:879\/623dc6a0749b3",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:879~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:879~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/69"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/70",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 71"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/70\/page\/galston:878",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/70\/page\/galston:878\/623dc6a15dfd0",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:878~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:878~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/70"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/71",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 72"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/71\/page\/galston:877",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/71\/page\/galston:877\/623dc6a24ae0b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:877~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:877~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/71"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/72",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 73"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/72\/page\/galston:876",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/72\/page\/galston:876\/623dc6a33b468",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:876~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:876~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/72"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/73",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 74"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/73\/page\/galston:875",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/73\/page\/galston:875\/623dc6a42b25b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:875~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:875~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/73"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/74",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 75"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/74\/page\/galston:874",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/74\/page\/galston:874\/623dc6a51a9cf",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:874~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:874~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/74"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/75",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 76"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/75\/page\/galston:873",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/75\/page\/galston:873\/623dc6a5ea572",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:873~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:873~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/75"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/76",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 77"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/76\/page\/galston:872",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/76\/page\/galston:872\/623dc6a6d4a9e",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:872~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:872~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/76"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/77",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 78"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/77\/page\/galston:871",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/77\/page\/galston:871\/623dc6a7b944f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:871~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:871~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/77"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/78",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 79"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/78\/page\/galston:870",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/78\/page\/galston:870\/623dc6a8a2d34",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:870~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:870~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/78"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/79",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 80"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/79\/page\/galston:869",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/79\/page\/galston:869\/623dc6a98ba56",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:869~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:869~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/79"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/80",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 81"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/80\/page\/galston:868",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/80\/page\/galston:868\/623dc6aa75e21",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:868~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:868~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/80"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/81",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 82"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/81\/page\/galston:867",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/81\/page\/galston:867\/623dc6ab60deb",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:867~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:867~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/81"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/82",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 83"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/82\/page\/galston:866",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/82\/page\/galston:866\/623dc6ac53b39",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:866~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:866~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/82"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/83",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 84"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/83\/page\/galston:865",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/83\/page\/galston:865\/623dc6ad39924",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:865~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:865~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/83"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/84",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 85"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/84\/page\/galston:864",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/84\/page\/galston:864\/623dc6ae25052",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:864~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:864~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/84"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/85",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 86"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/85\/page\/galston:863",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/85\/page\/galston:863\/623dc6af163a1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:863~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:863~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/85"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/86",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 87"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/86\/page\/galston:862",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/86\/page\/galston:862\/623dc6aff22d6",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:862~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:862~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/86"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/87",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 88"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/87\/page\/galston:861",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/87\/page\/galston:861\/623dc6b0e08e9",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:861~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:861~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/87"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/88",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 89"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/88\/page\/galston:860",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/88\/page\/galston:860\/623dc6b1cf3d9",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:860~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:860~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/88"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/89",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 90"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/89\/page\/galston:859",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/89\/page\/galston:859\/623dc6b2ba37f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:859~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:859~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/89"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/90",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 91"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/90\/page\/galston:858",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/90\/page\/galston:858\/623dc6b3a9208",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:858~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:858~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/90"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/91",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 92"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/91\/page\/galston:857",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/91\/page\/galston:857\/623dc6b494a6c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:857~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:857~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/91"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/92",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 93"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/92\/page\/galston:856",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/92\/page\/galston:856\/623dc6b5838c1",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:856~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:856~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/92"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/93",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 94"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/93\/page\/galston:855",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/93\/page\/galston:855\/623dc6b677d0c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:855~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:855~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/93"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/94",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 95"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/94\/page\/galston:854",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/94\/page\/galston:854\/623dc6b75dbc8",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:854~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:854~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/94"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/95",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 96"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/95\/page\/galston:853",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/95\/page\/galston:853\/623dc6b849aa4",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:853~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:853~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/95"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/96",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 97"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/96\/page\/galston:852",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/96\/page\/galston:852\/623dc6b933f98",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:852~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:852~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/96"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/97",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 98"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/97\/page\/galston:851",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/97\/page\/galston:851\/623dc6ba21753",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:851~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:851~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/97"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/98",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 99"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/98\/page\/galston:850",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/98\/page\/galston:850\/623dc6bb0d9fe",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:850~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:850~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/98"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/99",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 100"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/99\/page\/galston:849",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/99\/page\/galston:849\/623dc6bbeb08b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:849~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:849~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/99"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/100",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 101"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/100\/page\/galston:848",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/100\/page\/galston:848\/623dc6bcd6d86",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:848~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:848~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/100"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/101",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 102"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/101\/page\/galston:847",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/101\/page\/galston:847\/623dc6bdbfd20",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:847~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:847~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/101"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/102",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 103"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/102\/page\/galston:846",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/102\/page\/galston:846\/623dc6bea1d63",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:846~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:846~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/102"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/103",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 104"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/103\/page\/galston:845",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/103\/page\/galston:845\/623dc6bf91859",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:845~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:845~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/103"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/104",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 105"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/104\/page\/galston:844",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/104\/page\/galston:844\/623dc6c07ee21",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:844~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:844~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/104"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/105",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 106"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/105\/page\/galston:843",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/105\/page\/galston:843\/623dc6c1746d8",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:843~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:843~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/105"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/106",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 107"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/106\/page\/galston:842",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/106\/page\/galston:842\/623dc6c25ff82",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:842~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:842~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/106"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/107",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 108"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/107\/page\/galston:841",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/107\/page\/galston:841\/623dc6c34c60e",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:841~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:841~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/107"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/108",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 109"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/108\/page\/galston:840",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/108\/page\/galston:840\/623dc6c4365f5",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:840~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:840~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/108"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/109",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 110"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/109\/page\/galston:839",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/109\/page\/galston:839\/623dc6c521370",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:839~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:839~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/109"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/110",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 111"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/110\/page\/galston:838",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/110\/page\/galston:838\/623dc6c611ff3",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:838~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:838~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/110"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/111",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 112"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/111\/page\/galston:837",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/111\/page\/galston:837\/623dc6c6f1ec0",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:837~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:837~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/111"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/112",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 113"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/112\/page\/galston:836",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/112\/page\/galston:836\/623dc6c7e18c8",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:836~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:836~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/112"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/113",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 114"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/113\/page\/galston:835",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/113\/page\/galston:835\/623dc6c8c18d4",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:835~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:835~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/113"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/114",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 115"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/114\/page\/galston:834",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/114\/page\/galston:834\/623dc6c9accbf",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:834~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:834~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/114"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/115",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 116"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/115\/page\/galston:833",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/115\/page\/galston:833\/623dc6ca9ead8",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:833~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:833~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/115"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/116",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 117"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/116\/page\/galston:832",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/116\/page\/galston:832\/623dc6cb9003e",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:832~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:832~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/116"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/117",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 118"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/117\/page\/galston:831",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/117\/page\/galston:831\/623dc6cc76d71",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:831~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:831~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/117"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/118",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 119"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/118\/page\/galston:830",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/118\/page\/galston:830\/623dc6cd64989",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:830~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:830~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/118"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/119",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 120"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/119\/page\/galston:829",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/119\/page\/galston:829\/623dc6ce523ad",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:829~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:829~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/119"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/120",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 121"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/120\/page\/galston:828",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/120\/page\/galston:828\/623dc6cf3b4b2",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:828~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:828~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/120"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/121",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 122"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/121\/page\/galston:827",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/121\/page\/galston:827\/623dc6d01ca19",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:827~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:827~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/121"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/122",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 123"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/122\/page\/galston:826",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/122\/page\/galston:826\/623dc6d10845c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:826~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:826~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/122"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/123",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 124"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/123\/page\/galston:825",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/123\/page\/galston:825\/623dc6d1ed898",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:825~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:825~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/123"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/124",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 125"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/124\/page\/galston:824",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/124\/page\/galston:824\/623dc6d2d7cb7",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:824~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:824~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/124"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/125",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 126"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/125\/page\/galston:823",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/125\/page\/galston:823\/623dc6d3cb979",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:823~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:823~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/125"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/126",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 127"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/126\/page\/galston:822",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/126\/page\/galston:822\/623dc6d4bf1a0",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:822~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:822~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/126"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/127",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 128"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/127\/page\/galston:821",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/127\/page\/galston:821\/623dc6d5af3f6",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:821~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:821~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/127"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/128",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 129"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/128\/page\/galston:820",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/128\/page\/galston:820\/623dc6d69a3bb",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:820~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:820~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/128"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/129",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 130"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/129\/page\/galston:819",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/129\/page\/galston:819\/623dc6d788f20",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:819~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:819~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/129"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/130",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 131"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/130\/page\/galston:818",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/130\/page\/galston:818\/623dc6d87bc5c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:818~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:818~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/130"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/131",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 132"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/131\/page\/galston:817",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/131\/page\/galston:817\/623dc6d96d576",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:817~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:817~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/131"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/132",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 133"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/132\/page\/galston:816",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/132\/page\/galston:816\/623dc6da5a40a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:816~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:816~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/132"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/133",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 134"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/133\/page\/galston:815",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/133\/page\/galston:815\/623dc6db4603a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:815~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:815~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/133"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/134",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 135"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/134\/page\/galston:814",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/134\/page\/galston:814\/623dc6dc30c38",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:814~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:814~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/134"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/135",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 136"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/135\/page\/galston:813",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/135\/page\/galston:813\/623dc6dd21e8a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:813~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:813~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/135"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/136",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 137"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/136\/page\/galston:812",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/136\/page\/galston:812\/623dc6de0bf71",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:812~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:812~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/136"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/137",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 138"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/137\/page\/galston:811",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/137\/page\/galston:811\/623dc6dee9988",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:811~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:811~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/137"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/138",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 139"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/138\/page\/galston:810",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/138\/page\/galston:810\/623dc6dfdb6e8",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:810~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:810~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/138"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/139",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 140"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/139\/page\/galston:809",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/139\/page\/galston:809\/623dc6e0c66dd",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:809~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:809~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/139"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/140",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 141"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/140\/page\/galston:808",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/140\/page\/galston:808\/623dc6e1b168d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:808~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:808~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/140"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/141",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 142"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/141\/page\/galston:807",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/141\/page\/galston:807\/623dc6e2a0a72",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:807~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:807~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/141"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/142",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 143"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/142\/page\/galston:806",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/142\/page\/galston:806\/623dc6e390ed9",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:806~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:806~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/142"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/143",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 144"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/143\/page\/galston:805",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/143\/page\/galston:805\/623dc6e47f925",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:805~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:805~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/143"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/144",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 145"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/144\/page\/galston:804",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/144\/page\/galston:804\/623dc6e56d9f6",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:804~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:804~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/144"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/145",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 146"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/145\/page\/galston:803",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/145\/page\/galston:803\/623dc6e65b91c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:803~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:803~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/145"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/146",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 147"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/146\/page\/galston:802",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/146\/page\/galston:802\/623dc6e748e25",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:802~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:802~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/146"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/147",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 148"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/147\/page\/galston:801",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/147\/page\/galston:801\/623dc6e82b964",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:801~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:801~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/147"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/148",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 149"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/148\/page\/galston:800",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/148\/page\/galston:800\/623dc6e917b09",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:800~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:800~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/148"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/149",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 150"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/149\/page\/galston:799",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/149\/page\/galston:799\/623dc6ea01ee3",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:799~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:799~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/149"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/150",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 151"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/150\/page\/galston:798",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/150\/page\/galston:798\/623dc6eae2044",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:798~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:798~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/150"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/151",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 152"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/151\/page\/galston:797",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/151\/page\/galston:797\/623dc6ebcf004",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:797~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:797~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/151"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/152",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 153"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/152\/page\/galston:796",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/152\/page\/galston:796\/623dc6ecc9e06",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:796~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:796~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/152"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/153",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 154"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/153\/page\/galston:795",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/153\/page\/galston:795\/623dc6edb2018",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:795~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:795~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/153"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/154",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 155"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/154\/page\/galston:794",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/154\/page\/galston:794\/623dc6ee9ab57",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:794~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:794~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/154"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/155",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 156"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/155\/page\/galston:793",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/155\/page\/galston:793\/623dc6ef8a309",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:793~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:793~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/155"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/156",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 157"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/156\/page\/galston:792",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/156\/page\/galston:792\/623dc6f073761",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:792~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:792~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/156"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/157",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 158"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/157\/page\/galston:791",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/157\/page\/galston:791\/623dc6f15ea6d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:791~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:791~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/157"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/158",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 159"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/158\/page\/galston:790",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/158\/page\/galston:790\/623dc6f249ae5",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:790~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:790~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/158"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/159",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 160"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/159\/page\/galston:789",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/159\/page\/galston:789\/623dc6f335eb7",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:789~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:789~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/159"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/160",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 161"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/160\/page\/galston:788",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/160\/page\/galston:788\/623dc6f41ebc8",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:788~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:788~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/160"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/161",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 162"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/161\/page\/galston:787",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/161\/page\/galston:787\/623dc6f50df3b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:787~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:787~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/161"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/162",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 163"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/162\/page\/galston:786",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/162\/page\/galston:786\/623dc6f5eae5c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:786~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:786~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/162"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/163",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 164"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/163\/page\/galston:785",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/163\/page\/galston:785\/623dc6f6c9a81",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:785~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:785~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/163"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/164",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 165"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/164\/page\/galston:784",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/164\/page\/galston:784\/623dc6f7a9a58",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:784~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:784~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/164"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/165",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 166"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/165\/page\/galston:783",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/165\/page\/galston:783\/623dc6f895aa5",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:783~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:783~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/165"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/166",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 167"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/166\/page\/galston:782",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/166\/page\/galston:782\/623dc6f9831a5",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:782~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:782~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/166"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/167",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 168"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/167\/page\/galston:781",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/167\/page\/galston:781\/623dc6fa6f11b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:781~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:781~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/167"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/168",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 169"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/168\/page\/galston:780",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/168\/page\/galston:780\/623dc6fb61a40",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:780~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:780~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/168"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/169",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 170"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/169\/page\/galston:779",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/169\/page\/galston:779\/623dc6fc51b69",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:779~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:779~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/169"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/170",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 171"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/170\/page\/galston:778",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/170\/page\/galston:778\/623dc6fd3d81b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:778~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:778~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/170"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/171",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 172"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/171\/page\/galston:777",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/171\/page\/galston:777\/623dc6fe2d9ce",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:777~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:777~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/171"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/172",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 173"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/172\/page\/galston:776",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/172\/page\/galston:776\/623dc6ff2f0a5",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:776~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:776~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/172"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/173",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 174"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/173\/page\/galston:775",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/173\/page\/galston:775\/623dc70018d1b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:775~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:775~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/173"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/174",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 175"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/174\/page\/galston:774",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/174\/page\/galston:774\/623dc700f315e",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:774~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:774~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/174"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/175",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 176"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/175\/page\/galston:773",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/175\/page\/galston:773\/623dc701de262",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:773~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:773~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/175"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/176",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 177"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/176\/page\/galston:772",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/176\/page\/galston:772\/623dc702cd005",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:772~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:772~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/176"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/177",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 178"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/177\/page\/galston:771",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/177\/page\/galston:771\/623dc703b65c6",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:771~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:771~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/177"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/178",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 179"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/178\/page\/galston:770",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/178\/page\/galston:770\/623dc704a341b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:770~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:770~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/178"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/179",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 180"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/179\/page\/galston:769",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/179\/page\/galston:769\/623dc70597ca9",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:769~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:769~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/179"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/180",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 181"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/180\/page\/galston:768",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/180\/page\/galston:768\/623dc70681964",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:768~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:768~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/180"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/181",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 182"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/181\/page\/galston:767",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/181\/page\/galston:767\/623dc707717e7",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:767~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:767~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/181"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/182",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 183"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/182\/page\/galston:766",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/182\/page\/galston:766\/623dc7085bb62",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:766~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:766~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/182"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/183",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 184"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/183\/page\/galston:765",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/183\/page\/galston:765\/623dc70949b2d",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:765~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:765~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/183"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/184",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 185"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/184\/page\/galston:764",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/184\/page\/galston:764\/623dc70a36312",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:764~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:764~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/184"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/185",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 186"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/185\/page\/galston:763",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/185\/page\/galston:763\/623dc70b202cf",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:763~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:763~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/185"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/186",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 187"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/186\/page\/galston:762",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/186\/page\/galston:762\/623dc70c0fd8b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:762~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:762~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/186"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/187",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 188"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/187\/page\/galston:761",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/187\/page\/galston:761\/623dc70cee380",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:761~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:761~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/187"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/188",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 189"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/188\/page\/galston:760",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/188\/page\/galston:760\/623dc70dda696",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:760~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:760~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/188"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/189",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 190"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/189\/page\/galston:759",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/189\/page\/galston:759\/623dc70ec7397",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:759~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:759~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/189"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/190",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 191"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/190\/page\/galston:758",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/190\/page\/galston:758\/623dc70fb1f4b",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:758~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:758~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/190"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/191",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 192"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/191\/page\/galston:757",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/191\/page\/galston:757\/623dc7109d710",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:757~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:757~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/191"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/192",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 193"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/192\/page\/galston:756",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/192\/page\/galston:756\/623dc7118c127",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:756~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:756~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/192"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/193",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 194"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/193\/page\/galston:755",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/193\/page\/galston:755\/623dc71278d65",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:755~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:755~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/193"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/194",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 195"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/194\/page\/galston:754",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/194\/page\/galston:754\/623dc71364787",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:754~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:754~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/194"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/195",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 196"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/195\/page\/galston:753",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/195\/page\/galston:753\/623dc714594c5",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:753~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:753~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/195"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/196",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 197"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/196\/page\/galston:752",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/196\/page\/galston:752\/623dc7154414c",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:752~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:752~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/196"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/197",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 198"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/197\/page\/galston:751",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/197\/page\/galston:751\/623dc7162f18a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:751~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:751~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/197"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/198",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 199"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/198\/page\/galston:750",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/198\/page\/galston:750\/623dc7171a91f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:750~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:750~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/198"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/199",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 200"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/199\/page\/galston:749",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/199\/page\/galston:749\/623dc7180078f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:749~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:749~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/199"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/200",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 201"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/200\/page\/galston:748",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/200\/page\/galston:748\/623dc718eacec",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:748~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:748~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/200"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/201",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 202"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/201\/page\/galston:747",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/201\/page\/galston:747\/623dc719e4f82",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:747~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:747~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/201"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/202",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 203"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/202\/page\/galston:746",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/202\/page\/galston:746\/623dc71ad49ed",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:746~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:746~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/202"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/203",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 204"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/203\/page\/galston:745",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/203\/page\/galston:745\/623dc71bc2836",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:745~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:745~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/203"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/204",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 205"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/204\/page\/galston:744",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/204\/page\/galston:744\/623dc71caf438",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:744~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:744~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/204"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/205",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 206"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/205\/page\/galston:743",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/205\/page\/galston:743\/623dc71d9ea0a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:743~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:743~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/205"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/206",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 207"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/206\/page\/galston:742",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/206\/page\/galston:742\/623dc71e89278",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:742~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:742~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/206"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/207",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 208"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/207\/page\/galston:741",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/207\/page\/galston:741\/623dc71f73ec2",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:741~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:741~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/207"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/208",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 209"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/208\/page\/galston:740",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/208\/page\/galston:740\/623dc7205cc60",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:740~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:740~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/208"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/209",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 210"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/209\/page\/galston:739",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/209\/page\/galston:739\/623dc72148f3a",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:739~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:739~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/209"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/210",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Studienbuch : page 211"
+        ]
+      },
+      "width": 3400,
+      "height": 4400,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/210\/page\/galston:738",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/210\/page\/galston:738\/623dc7224316f",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:738~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3400,
+                  "height": 4400,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston:738~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736\/canvas\/210"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "seeAlso": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/collections\/islandora\/object\/galston%3A736\/datastream\/MODS",
+      "type": "Dataset",
+      "label": {
+        "en": [
+          "Bibliographic Description in MODS"
+        ]
+      },
+      "format": "application\/xml",
+      "profile": "http:\/\/www.loc.gov\/standards\/mods\/v3\/mods-3-5.xsd"
+    }
+  ],
+  "behavior": [
+    "paged"
+  ]
+}

--- a/iiif/galston_736.json
+++ b/iiif/galston_736.json
@@ -2,7 +2,7 @@
   "@context": [
     "https:\/\/iiif.io\/api\/presentation\/3\/context.json"
   ],
-  "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/736",
+  "id": "https:\/\/digital.lib.utk.edu\/static\/iiif\/galston_736.json",
   "type": "Manifest",
   "label": {
     "en": [

--- a/iiif/galston_948.json
+++ b/iiif/galston_948.json
@@ -2,7 +2,7 @@
   "@context": [
     "https:\/\/iiif.io\/api\/presentation\/3\/context.json"
   ],
-  "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/948",
+  "id": "https:\/\/digital.lib.utk.edu\/static\/iiif\/galston_948.json",
   "type": "Manifest",
   "label": {
     "en": [

--- a/iiif/galston_948.json
+++ b/iiif/galston_948.json
@@ -1,0 +1,213 @@
+{
+  "@context": [
+    "https:\/\/iiif.io\/api\/presentation\/3\/context.json"
+  ],
+  "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/948",
+  "type": "Manifest",
+  "label": {
+    "en": [
+      "Variations, Musical Courier, volume LXV, number 1"
+    ]
+  },
+  "summary": {
+    "en": [
+      "Review of Gottfried Galston's Studienbuch stressing how accessible the text makes canonical works for students and teachers of piano music."
+    ]
+  },
+  "metadata": [
+    {
+      "label": {
+        "en": [
+          "Publication Date"
+        ]
+      },
+      "value": {
+        "en": [
+          "July 3, 1912",
+          "1912-07-03"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Format"
+        ]
+      },
+      "value": {
+        "en": [
+          "periodicals"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Extent"
+        ]
+      },
+      "value": {
+        "en": [
+          "1 page"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Subject"
+        ]
+      },
+      "value": {
+        "en": [
+          "Music",
+          "Piano music"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Description"
+        ]
+      },
+      "value": {
+        "en": [
+          "Review of Gottfried Galston's Studienbuch stressing how accessible the text makes canonical works for students and teachers of piano music."
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Language"
+        ]
+      },
+      "value": {
+        "en": [
+          "English"
+        ]
+      }
+    },
+    {
+      "label": {
+        "en": [
+          "Author"
+        ]
+      },
+      "value": {
+        "en": [
+          "Liebling, Leonard"
+        ]
+      }
+    }
+  ],
+  "rights": "http:\/\/rightsstatements.org\/vocab\/NoC-US\/1.0\/",
+  "requiredStatement": {
+    "label": {
+      "en": [
+        "Provided by"
+      ]
+    },
+    "value": {
+      "en": [
+        "University of Tennessee, Knoxville. Libraries"
+      ]
+    }
+  },
+  "provider": [
+    {
+      "id": "https:\/\/www.lib.utk.edu\/about\/",
+      "type": "Agent",
+      "label": {
+        "en": [
+          "University of Tennessee, Knoxville. Libraries"
+        ]
+      },
+      "homepage": [
+        {
+          "id": "https:\/\/www.lib.utk.edu\/",
+          "type": "Text",
+          "label": {
+            "en": [
+              "University of Tennessee Libraries Homepage"
+            ]
+          },
+          "format": "text\/html"
+        }
+      ],
+      "logo": [
+        {
+          "id": "https:\/\/utkdigitalinitiatives.github.io\/iiif-level-0\/ut_libraries_centered\/full\/full\/0\/default.jpg",
+          "type": "Image",
+          "format": "image\/jpeg",
+          "width": 200,
+          "height": 200
+        }
+      ]
+    }
+  ],
+  "thumbnail": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston%3A948~datastream~JP2\/full\/max\/0\/default.jpg",
+      "width": 3365,
+      "height": 4546,
+      "type": "Image",
+      "format": "image\/jpeg"
+    }
+  ],
+  "items": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/948\/canvas\/0",
+      "type": "Canvas",
+      "label": {
+        "none": [
+          "Variations, Musical Courier, volume LXV, number 1"
+        ]
+      },
+      "width": 3365,
+      "height": 4546,
+      "items": [
+        {
+          "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/948\/canvas\/0\/page\/galston%3A948",
+          "type": "AnnotationPage",
+          "items": [
+            {
+              "id": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/948\/canvas\/0\/page\/galston%3A948\/623dc723e8a59",
+              "type": "Annotation",
+              "motivation": "painting",
+              "body": [
+                {
+                  "id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston%3A948~datastream~JP2\/full\/full\/0\/default.jpg",
+                  "type": "Image",
+                  "width": 3365,
+                  "height": 4546,
+                  "format": "image\/jpeg",
+                  "service": {
+                    "@id": "https:\/\/digital.lib.utk.edu\/iiif\/2\/collections~islandora~object~galston%3A948~datastream~JP2",
+                    "@type": "http:\/\/iiif.io\/api\/image\/2\/context.json",
+                    "profile": "http:\/\/iiif.io\/api\/image\/2\/level2.json"
+                  }
+                }
+              ],
+              "target": "https:\/\/digital.lib.utk.edu\/assemble\/manifest\/galston\/948\/canvas\/0"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "seeAlso": [
+    {
+      "id": "https:\/\/digital.lib.utk.edu\/collections\/islandora\/object\/galston%3A948\/datastream\/MODS",
+      "type": "Dataset",
+      "label": {
+        "en": [
+          "Bibliographic Description in MODS"
+        ]
+      },
+      "format": "application\/xml",
+      "profile": "http:\/\/www.loc.gov\/standards\/mods\/v3\/mods-3-5.xsd"
+    }
+  ]
+}

--- a/iiif/galston_949.json
+++ b/iiif/galston_949.json
@@ -2,7 +2,7 @@
   "@context": [
     "https://iiif.io/api/presentation/3/context.json"
   ],
-  "id": "https://digital.lib.utk.edu/assemble/manifest/galston/949",
+  "id": "https:\/\/digital.lib.utk.edu\/static\/iiif\/galston_949.json",
   "type": "Manifest",
   "label": {
     "en": [


### PR DESCRIPTION
# What does this do?

Adds dynamic manifests used by Galston as static manifests unless they already exist in a static version (galston:694 / galston_694)

# Why are we doing this?

This avoids us having to deal with technical debt in exhibits for a bit and buys us time to work on other things.

After this is here, we can simply replace the dynamic calls with static ones.

# How can I test?

Good question.  This will be hard to do until the work is done, but here was my approach:


Let's figure out when we reference a dynamic manifest potentially:

``` sh
grep -nri digital.lib.utk.edu/assemble > ../all_assemble_references.txt

```

Now let's just focus in on the manifests ignoring canvases and annotations and write them as json:

``` python
import requests

unique_manifests = []

with open('/home/mark/code/exhibits/all_assemble_references.txt', 'r') as all_assemble:
    for thing in all_assemble:
        if 'data-manifest' in thing and 'galston' in thing:
            manifest = thing.split('data-manifest="')[1].split('"')[0]
            if manifest not in unique_manifests:
                unique_manifests.append(manifest)

for manifest in unique_manifests:
    pid = manifest.split('https://digital.lib.utk.edu/assemble/manifest/')[1].replace('/', '_')
    r = requests.get(manifest)
    print(manifest)
    with open(f'output/{pid}.json', 'wb') as manifest_json:
        manifest_json.write(r.content)
```

This gets everything plus one that we are already tracking.  Have a better or different way to answer the problem?  If so, do you find a discrepancy?

# Does this solve all of EXHIBIT-114?

Absolutely not.  We still have to address things in exhibits, but that work can only be done after this is reviewed, approved, merged, and deployed.